### PR TITLE
Creating the Injection and Meal representations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ gem "jets"
 
 gem "pg", "~> 1.1"
 
+group :development do
+  gem 'rubocop'
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
+    ast (2.4.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.190.0)
     aws-sdk-apigateway (1.33.0)
@@ -95,6 +96,7 @@ GEM
     hashie (3.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.3)
     jets (1.9.30)
       actionmailer (~> 5.2.1)
       actionpack (~> 5.2.1)
@@ -152,6 +154,9 @@ GEM
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    parallel (1.17.0)
+    parser (2.6.3.0)
+      ast (~> 2.4.0)
     pg (1.1.4)
     public_suffix (3.1.1)
     puma (4.0.1)
@@ -186,6 +191,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    rubocop (0.73.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
     shotgun (0.9.2)
       rack (>= 1.0)
     text-table (1.2.4)
@@ -193,6 +206,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.6.0)
     zeitwerk (2.1.9)
 
 PLATFORMS
@@ -206,6 +220,7 @@ DEPENDENCIES
   puma
   rack
   rspec
+  rubocop
   shotgun
 
 BUNDLED WITH

--- a/app/models/health/injection.rb
+++ b/app/models/health/injection.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Health
+  class Injection < ::ApplicationRecord
+    enum injection_type: %i[basal bolus]
+  end
+end

--- a/app/models/health/meal.rb
+++ b/app/models/health/meal.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Health
+  class Meal < ::ApplicationRecord
+    enum meal_type: %i[breakfast almuerzo lunch merienda dinner other]
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,11 @@
 default: &default
   adapter: postgresql
   encoding: utf8
-  pool: <%= ENV["DB_POOL"] || 5  %>
-  database: <%= ENV['DB_NAME'] || 'alexgascon-api_development' %>
-  username: <%= ENV['DB_USER'] || 'root' %>
-  password: <%= ENV['DB_PASS'] %>
-  host: <%= ENV["DB_HOST"] %>
-  url: <%= ENV['DATABASE_URL'] %> # takes higher precedence than other settings
+  pool: 5
+  database: 'alexgascon-api_development'
+  username: 'postgres'
+  password:
+  host: localhost
 
 development:
   <<: *default

--- a/db/migrate/20190721224619_create_injections.rb
+++ b/db/migrate/20190721224619_create_injections.rb
@@ -1,0 +1,11 @@
+class CreateInjections < ActiveRecord::Migration[5.2]
+  def change
+    create_table :injections do |t|
+      t.float :units
+      t.text :notes
+      t.integer :injection_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190721230937_create_meals.rb
+++ b/db/migrate/20190721230937_create_meals.rb
@@ -1,0 +1,13 @@
+class CreateMeals < ActiveRecord::Migration[5.2]
+  def change
+    create_table :meals do |t|
+      t.float :carbohydrates_portions
+      t.date :date
+      t.string :food
+      t.integer :meal_type
+      t.text :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,36 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_07_21_230937) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "injections", force: :cascade do |t|
+    t.float "units"
+    t.text "notes"
+    t.integer "injection_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "meals", force: :cascade do |t|
+    t.float "carbohydrates_portions"
+    t.date "date"
+    t.string "food"
+    t.integer "meal_type"
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
### What?
Creating the Meal and Injection models + the migrations required to create
the DB tables that will store their data.

### How?
The models contain exactly the same fields that have been included in their
original version (the one present in the alexgascon/alexgascon repo),
except for the following minor changes:

* The field `inserted_at` has been renamed to `created_at`, to follow  Rails' convention
* The fields `Injection.injection_type` and `Meal.meal_type` have been converted to enums (see Rails documentation for more info on enums) as their value should never be different than the ones represented in that subset.
* We have removed from Meal those fields that are not specifically related with a Meal (e.g. `pre/post_blood_glucose`, `insulin_units`), as we want to start representing these values in its respective models