### PR TITLE
Modifying SNS message processing to include correct structure

### DIFF
--- a/app/parsers/sns_parser.rb
+++ b/app/parsers/sns_parser.rb
@@ -4,6 +4,7 @@ class SnsParser
   attr_reader :event
 
   def initialize(event)
-    @event = JSON.parse(event).with_indifferent_access
+    sns_payload = event['Records'].first['Sns']
+    @event = JSON.parse(sns_payload['Message']).with_indifferent_access
   end
 end

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-Aws.config.update({
+Aws.config.update(
   region: 'eu-west-1',
-  credentials: Aws::Credentials.new(
-    ENV['AWS_ACCESS_KEY_ID'],
-    ENV['AWS_SECRET_ACCESS_KEY']
-  )
-})
+  credentials: Aws::Credentials.new(ENV['AWS_ACCESS'], ENV['AWS_SECRET'])
+)

--- a/spec/fixtures/sns_events/health/InsulinInjected.json
+++ b/spec/fixtures/sns_events/health/InsulinInjected.json
@@ -1,5 +1,22 @@
 {
-    "type": "basal",
-    "notes": "Injection testing notes",
-    "units": 15
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-1:598877714121:InsulinInjected:bb252d77-c541-46c0-8a9e-5ba5aa45ee35",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "9d044cb2-0d73-5525-a38e-19048502e12c",
+        "TopicArn": "arn:aws:sns:eu-west-1:598877714121:InsulinInjected",
+        "Subject": null,
+        "Message": "{\"units\": 15, \"type\": \"basal\", \"notes\": \"Injection testing notes\"}",
+        "Timestamp": "2019-07-27T17:13:21.905Z",
+        "SignatureVersion": "1",
+        "Signature": "DHe9GXILX41drnka/cgWVHFgO/+1Y39n0ERJzfSB/NoHE4K53DpdOrFC1tZUX/polhjgVL8XEZMoWC/p5mxv5di6vbqRqpyErldvKU3Maz6X06MKNoPlHUgeTRIruUa4Nd0tT049x5Chbym1AiK1a+/XTII0+UNk4SfEKuvMW4rlH3saRezWXKgUHhV3LuxhcAVpjQ0jdpvHxZqPTBCMe4dfY5RWCdHxHF83aAOEGJvjuoOoTmqnc1XGIJXTzQEBukBsD5ePIyTrWeZzVV+JJL7VpvEr26syasa7bgz6/qTa4AKjuu5GEZ2zR1J90C8DQJ1Ev1BJxZIFywWq0OsuSQ==",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe\\u0026SubscriptionArn=arn:aws:sns:eu-west-1:598877714121:InsulinInjected:bb252d77-c541-46c0-8a9e-5ba5aa45ee35",
+        "MessageAttributes": {}
+      }
+    }
+  ]
 }

--- a/spec/fixtures/sns_events/health/MealEaten-no_date.json
+++ b/spec/fixtures/sns_events/health/MealEaten-no_date.json
@@ -1,6 +1,22 @@
 {
-    "carbohydrates_portions": 4,
-    "food": "Food for thought",
-    "meal_type": "almuerzo",
-    "notes": "Meal notes"
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-1:598877714121:MealEaten:a0c766c7-66ad-489c-a54e-de5432fc7db3",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "cee471b5-17d9-5377-84a6-2403c61b67a8",
+        "TopicArn": "arn:aws:sns:eu-west-1:598877714121:MealEaten",
+        "Subject": null,
+        "Message": "{\"carbohydrates_portions\": 4, \"food\": \"Food for thought\", \"meal_type\": \"almuerzo\", \"notes\": \"Meal notes\" }",
+        "Timestamp": "2019-07-27T22:26:10.884Z",
+        "SignatureVersion": "1",
+        "Signature": "cGotLKMlhViXN4JHnoB/XcznGpmTxTZwwJ38+9XeyVKe/YsQK7ORih42EMhd1rdn4srSkFEyIRIhMRXWQE9KQvQFcgmpO1epzqRO1cwS14+A28FdnDTCmNRqBDUIRGcW6GrwcErmzBeXk+6CBzUGOuM75jPRQgpSpzI32Pw3KgeNmpz+r7lj88hsfIdMukB1O/tJjbeafV1j7hCF6dDKwYdvPKfsEvSLS5TujV5eqkKTK00GZTHMZdjQIRuCoC/RCNEaqrpuCz1/Eo5ymY4WOMUi37S8+E+C5tTXQmCGZCiBkpW2sQ0oyPK9IpEcDCOmxFjxVgJhBdzz8FprKLjJFw==",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:598877714121:MealEaten:a0c766c7-66ad-489c-a54e-de5432fc7db3",
+        "MessageAttributes": {}
+      }
+    }
+  ]
 }

--- a/spec/fixtures/sns_events/health/MealEaten.json
+++ b/spec/fixtures/sns_events/health/MealEaten.json
@@ -1,7 +1,22 @@
 {
-    "carbohydrates_portions": 4,
-    "date": "2019-10-30",
-    "food": "Food for thought",
-    "meal_type": "almuerzo",
-    "notes": "Meal notes"
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-1:598877714121:MealEaten:a0c766c7-66ad-489c-a54e-de5432fc7db3",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "cee471b5-17d9-5377-84a6-2403c61b67a8",
+        "TopicArn": "arn:aws:sns:eu-west-1:598877714121:MealEaten",
+        "Subject": null,
+        "Message": "{\"carbohydrates_portions\": 4, \"food\": \"Food for thought\", \"date\": \"2019-10-30\", \"meal_type\": \"almuerzo\", \"notes\": \"Meal notes\" }",
+        "Timestamp": "2019-07-27T22:26:10.884Z",
+        "SignatureVersion": "1",
+        "Signature": "cGotLKMlhViXN4JHnoB/XcznGpmTxTZwwJ38+9XeyVKe/YsQK7ORih42EMhd1rdn4srSkFEyIRIhMRXWQE9KQvQFcgmpO1epzqRO1cwS14+A28FdnDTCmNRqBDUIRGcW6GrwcErmzBeXk+6CBzUGOuM75jPRQgpSpzI32Pw3KgeNmpz+r7lj88hsfIdMukB1O/tJjbeafV1j7hCF6dDKwYdvPKfsEvSLS5TujV5eqkKTK00GZTHMZdjQIRuCoC/RCNEaqrpuCz1/Eo5ymY4WOMUi37S8+E+C5tTXQmCGZCiBkpW2sQ0oyPK9IpEcDCOmxFjxVgJhBdzz8FprKLjJFw==",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:598877714121:MealEaten:a0c766c7-66ad-489c-a54e-de5432fc7db3",
+        "MessageAttributes": {}
+      }
+    }
+  ]
 }

--- a/spec/jobs/health/create_injection_job_spec.rb
+++ b/spec/jobs/health/create_injection_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Health::CreateInjectionJob do
   describe 'create_injection' do
-    let(:event) { File.read('spec/fixtures/sns_events/health/InsulinInjected.json') }
+    let(:event) { JSON.parse(File.read('spec/fixtures/sns_events/health/InsulinInjected.json')) }
 
     subject { described_class.perform_now(:create_injection, event) }
 

--- a/spec/jobs/health/create_meal_job_spec.rb
+++ b/spec/jobs/health/create_meal_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Health::CreateMealJob do
   describe 'create_meal' do
-    let(:event) { File.read('spec/fixtures/sns_events/health/MealEaten.json') }
+    let(:event) { JSON.parse(File.read('spec/fixtures/sns_events/health/MealEaten.json')) }
 
     subject { described_class.perform_now(:create_meal, event) }
 
@@ -23,7 +23,7 @@ RSpec.describe Health::CreateMealJob do
     end
 
     context 'when the event does not have any date' do
-      let(:event) { File.read('spec/fixtures/sns_events/health/MealEaten-no_date.json') }
+      let(:event) { JSON.parse(File.read('spec/fixtures/sns_events/health/MealEaten-no_date.json')) }
 
       it 'creates a new meal' do
         expect { subject }.to change { Health::Meal.all.count }.by(1)

--- a/spec/parsers/health/injection_parser_spec.rb
+++ b/spec/parsers/health/injection_parser_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Health::InjectionParser do
   let(:parser) { described_class.new(sns_event) }
 
   describe 'parse' do
-    let(:sns_event) { File.read('spec/fixtures/sns_events/health/InsulinInjected.json') }
+    let(:sns_event) { JSON.parse(File.read('spec/fixtures/sns_events/health/InsulinInjected.json')) }
 
     subject { parser.parse }
 

--- a/spec/parsers/health/meal_parser_spec.rb
+++ b/spec/parsers/health/meal_parser_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Health::MealParser do
   let(:parser) { described_class.new(sns_event) }
 
   describe 'parse' do
-    let(:sns_event) { File.read('spec/fixtures/sns_events/health/MealEaten.json') }
+    let(:sns_event) { JSON.parse(File.read('spec/fixtures/sns_events/health/MealEaten.json')) }
 
     subject { parser.parse }
 


### PR DESCRIPTION
## What?
The structure that we were assuming for the SNS events wasn't the correct one, because apart from the actual message there is also other metadata andinformation related with resources used (like the topic). In this commit we implement several changes to prepare our code for the actual payload format:
- **Changing the fixtures used in the tests**: this allows us to know if the rest of the code is correct or not
- **Parsing the JSON fixture in the tests**: the `event` object that our handlers receive is not a string as we expected, but a hash. Therefore, our tests will need to receive a hash too.
- **Modifying the parser**: changing the parsing logic to get to the actual message payload. It is important to note that `Records` can be an array, but as we expect our messages to get to us one by one, we'll assume that it's fine to always get the first (as it should be the only one)

Also, we have performed some minor changes in the way we initialize the AWS gem in commit a01727e. The changes are:
- Removing the curly braces, as they are innecessary if the hash is the only argument of the method
- Instantiating Aws::Credentials in a single line, as we are still under the 100 char limit
- Changing ENV var keys: the ones that we were using are reserved for Jets internally, so we've changed them to avoid collisions