### PR TITLE
Integrating with Dexcom API - Authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jets"
+gem "jets", "<= 1.9.30"
 
 gem 'climate_control'
 gem "dynamoid"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,11 @@ source "https://rubygems.org"
 
 gem "jets"
 
+gem 'climate_control'
 gem "dynamoid"
+gem "httparty"
+
+
 
 group :development do
   gem 'rubocop'
@@ -19,4 +23,5 @@ end
 group :test do
   gem 'rspec' # rspec test group only or we get the "irb: warn: can't alias context from irb_context warning" when starting jets console
   gem 'launchy'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     aws-sdk-sqs (1.19.0)
       aws-sdk-core (~> 3, >= 3.58.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ssm (1.52.0)
+    aws-sdk-ssm (1.53.0)
       aws-sdk-core (~> 3, >= 3.58.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
@@ -90,7 +90,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
     diff-lcs (1.3)
-    dotenv (2.7.4)
+    dotenv (2.7.5)
     dynamoid (3.2.0)
       activemodel (>= 4)
       aws-sdk-dynamodb (~> 1)
@@ -143,7 +143,7 @@ GEM
       text-table
       thor
       zeitwerk
-    jets-gems (0.1.0)
+    jets-gems (0.2.0)
       gems
     jets-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
@@ -168,7 +168,7 @@ GEM
     minitest (5.11.3)
     multi_xml (0.6.0)
     nio4r (2.4.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     null-logger (0.1.5)
     parallel (1.17.0)
@@ -183,7 +183,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.2.3)
       actionpack (= 5.2.3)
@@ -192,7 +192,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (12.3.2)
+    rake (12.3.3)
     recursive-open-struct (1.1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -228,7 +228,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.1.9)
+    zeitwerk (2.1.10)
 
 PLATFORMS
   ruby
@@ -238,7 +238,7 @@ DEPENDENCIES
   climate_control
   dynamoid
   httparty
-  jets
+  jets (<= 1.9.30)
   launchy
   puma
   rack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,10 @@ GEM
     builder (3.2.3)
     byebug (11.0.1)
     cfnresponse (0.4.0)
+    climate_control (0.2.0)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     diff-lcs (1.3)
     dotenv (2.7.4)
@@ -98,7 +101,11 @@ GEM
       json
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.0)
     hashie (3.6.0)
+    httparty (0.17.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
@@ -152,10 +159,14 @@ GEM
       mini_mime (>= 0.1.1)
     memoist (0.16.0)
     method_source (0.9.2)
+    mime-types (3.3)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0904)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    multi_xml (0.6.0)
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -204,6 +215,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
     shotgun (0.9.2)
       rack (>= 1.0)
     text-table (1.2.4)
@@ -212,6 +224,10 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
+    webmock (3.7.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     zeitwerk (2.1.9)
 
 PLATFORMS
@@ -219,7 +235,9 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  climate_control
   dynamoid
+  httparty
   jets
   launchy
   puma
@@ -227,6 +245,7 @@ DEPENDENCIES
   rspec
   rubocop
   shotgun
+  webmock
 
 BUNDLED WITH
    2.0.2

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,6 @@ Rake::Task.define_task(:environment)
 require 'dynamoid/tasks'
 require 'jets'
 
+Dir.glob("#{Jets.root}/lib/tasks/*.rake").each { |r| import r }
+
 Jets.load_tasks

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
+Rake::Task.define_task(:environment)
+
+require 'dynamoid/tasks'
 require 'jets'
+
 Jets.load_tasks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationController < Jets::Controller::Base
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < Jets::Controller::Base
+  def head(status)
+    render json: {}, status: status
+  end
 end

--- a/app/controllers/partners/dexcom/auth_controller.rb
+++ b/app/controllers/partners/dexcom/auth_controller.rb
@@ -6,6 +6,8 @@ module Partners
       def auth_callback
         return head :unauthorized if unauthorized?
 
+        auth_service.obtain_oauth_token
+
         head :ok
       end
 
@@ -13,6 +15,10 @@ module Partners
 
       def auth_code
         @auth_code ||= permitted_params[:authorization_code]
+      end
+
+      def auth_service
+        @auth_service ||= Partners::Dexcom::AuthService.new(auth_code)
       end
 
       def unauthorized?

--- a/app/controllers/partners/dexcom/auth_controller.rb
+++ b/app/controllers/partners/dexcom/auth_controller.rb
@@ -14,7 +14,7 @@ module Partners
       private
 
       def auth_code
-        @auth_code ||= permitted_params[:authorization_code]
+        @auth_code ||= permitted_params[:code]
       end
 
       def auth_service
@@ -26,7 +26,7 @@ module Partners
       end
 
       def permitted_params
-        params.permit(:authorization_code)
+        params.permit(:code)
       end
     end
   end

--- a/app/controllers/partners/dexcom/auth_controller.rb
+++ b/app/controllers/partners/dexcom/auth_controller.rb
@@ -6,7 +6,7 @@ module Partners
       def auth_callback
         return head :unauthorized if unauthorized?
 
-        auth_service.obtain_oauth_token
+        auth_service.obtain_oauth_token(auth_code)
 
         head :ok
       end
@@ -18,7 +18,7 @@ module Partners
       end
 
       def auth_service
-        @auth_service ||= Partners::Dexcom::AuthService.new(auth_code)
+        @auth_service ||= Partners::Dexcom::AuthService.new
       end
 
       def unauthorized?

--- a/app/controllers/partners/dexcom/auth_controller.rb
+++ b/app/controllers/partners/dexcom/auth_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Partners
+  module Dexcom
+    class AuthController < ::ApplicationController
+      def auth_callback
+        render json: { msg: "Works" }, status: :ok
+      end
+
+      private
+
+      def auth_code
+        @auth_code ||= permitted_params[:authorization_code]
+      end
+
+      def permitted_params
+        params.permit(:authorization_code)
+      end
+    end
+  end
+end

--- a/app/controllers/partners/dexcom/auth_controller.rb
+++ b/app/controllers/partners/dexcom/auth_controller.rb
@@ -4,6 +4,8 @@ module Partners
   module Dexcom
     class AuthController < ::ApplicationController
       def auth_callback
+        return render json: { error: "" }, status: :unauthorized if unauthorized?
+
         render json: { msg: "Works" }, status: :ok
       end
 
@@ -11,6 +13,10 @@ module Partners
 
       def auth_code
         @auth_code ||= permitted_params[:authorization_code]
+      end
+
+      def unauthorized?
+        auth_code.blank?
       end
 
       def permitted_params

--- a/app/controllers/partners/dexcom/auth_controller.rb
+++ b/app/controllers/partners/dexcom/auth_controller.rb
@@ -4,7 +4,7 @@ module Partners
   module Dexcom
     class AuthController < ::ApplicationController
       def auth_callback
-        return render json: { error: "" }, status: :unauthorized if unauthorized?
+        return render json: {}, status: :unauthorized if unauthorized?
 
         render json: { msg: "Works" }, status: :ok
       end

--- a/app/controllers/partners/dexcom/auth_controller.rb
+++ b/app/controllers/partners/dexcom/auth_controller.rb
@@ -4,9 +4,9 @@ module Partners
   module Dexcom
     class AuthController < ::ApplicationController
       def auth_callback
-        return render json: {}, status: :unauthorized if unauthorized?
+        return head :unauthorized if unauthorized?
 
-        render json: { msg: "Works" }, status: :ok
+        head :ok
       end
 
       private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,2 @@
+module ApplicationHelper
+end

--- a/app/helpers/dynamoid_helper.rb
+++ b/app/helpers/dynamoid_helper.rb
@@ -2,8 +2,14 @@
 
 class DynamoidHelper
   def self.create_tables
-    Dynamoid.included_models.each do |model|
-      model.create_table
-    end
+    load_models
+
+    Dynamoid.included_models.each(&:create_table)
+  end
+
+  private
+
+  def load_models
+    Dir[File.join(Dynamoid::Config.models_dir, '**/*.rb')].sort.each { |file| require file }
   end
 end

--- a/app/helpers/dynamoid_helper.rb
+++ b/app/helpers/dynamoid_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DynamoidHelper
+  def self.create_tables
+    Dynamoid.included_models.each do |model|
+      model.create_table
+    end
+  end
+end

--- a/app/models/partners/dexcom/auth_token.rb
+++ b/app/models/partners/dexcom/auth_token.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Partners
+  module Dexcom
+    class AuthToken
+      include Dynamoid::Document
+
+      field :account_id, :string
+      field :access_token, :string
+      field :expiration_time, :number 
+      field :refresh_token, :string
+      
+      validates_presence_of :account_id
+      validates_presence_of :access_token
+      validates_presence_of :refresh_token
+    end
+  end
+end

--- a/app/models/partners/dexcom/auth_token.rb
+++ b/app/models/partners/dexcom/auth_token.rb
@@ -5,14 +5,15 @@ module Partners
     class AuthToken
       include Dynamoid::Document
 
-      field :account_id, :string
       field :access_token, :string
       field :expiration_time, :number 
       field :refresh_token, :string
-      
-      validates_presence_of :account_id
-      validates_presence_of :access_token
-      validates_presence_of :refresh_token
+
+      def self.instance
+        return new if count.zero?
+
+        first
+      end
     end
   end
 end

--- a/app/models/partners/dexcom/auth_token.rb
+++ b/app/models/partners/dexcom/auth_token.rb
@@ -5,6 +5,7 @@ module Partners
     class AuthToken
       include Dynamoid::Document
 
+      field :authorization_code, :string
       field :access_token, :string
       field :expiration_time, :number 
       field :refresh_token, :string

--- a/app/models/partners/dexcom/auth_token.rb
+++ b/app/models/partners/dexcom/auth_token.rb
@@ -11,7 +11,7 @@ module Partners
       field :refresh_token, :string
 
       def self.instance
-        return new if count.zero?
+        create if first.nil?
 
         first
       end

--- a/app/services/partners/dexcom/auth_service.rb
+++ b/app/services/partners/dexcom/auth_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Partners
+  module Dexcom
+    class AuthService
+      def initialize(authorization_code)
+        @authorization_code = authorization_code
+      end
+
+      def obtain_oauth_token
+      end
+    end
+  end
+end

--- a/app/services/partners/dexcom/auth_service.rb
+++ b/app/services/partners/dexcom/auth_service.rb
@@ -3,11 +3,38 @@
 module Partners
   module Dexcom
     class AuthService
+      attr_reader :authorization_code
+
       def initialize(authorization_code)
         @authorization_code = authorization_code
       end
 
       def obtain_oauth_token
+        HTTParty.post(
+          endpoint_url,
+          headers: headers,
+          body: body
+        )
+      end
+
+      private
+
+      def endpoint_url
+        "#{ENV['DEXCOM_URL']}/v2/oauth2/token"
+      end
+
+      def headers
+        { 'Content-Type': 'application/x-www-form-urlencoded' }
+      end
+
+      def body
+        {
+          client_id: ENV['DEXCOM_CLIENT_ID'],
+          client_secret: ENV['DEXCOM_CLIENT_SECRET'],
+          code: authorization_code,
+          grant_type: 'authorization_code',
+          redirect_uri: ENV['DEXCOM_REDIRECT_URI']
+        }
       end
     end
   end

--- a/app/services/partners/dexcom/auth_service.rb
+++ b/app/services/partners/dexcom/auth_service.rb
@@ -10,14 +10,25 @@ module Partners
       end
 
       def obtain_oauth_token
-        HTTParty.post(
-          endpoint_url,
-          headers: headers,
-          body: body
-        )
+        @response = request_auth_token
+        token_attributes = extract_auth_token
+
+        token.update_attributes!(token_attributes)
       end
 
       private
+
+      def request_auth_token
+        HTTParty.post(endpoint_url, headers: headers, body: body)
+      end
+
+      def extract_auth_token
+        {
+          access_token: response_body['access_token'],
+          expiration_time: Time.now.to_i + response_body['expires_in'].to_i,
+          refresh_token: response_body['refresh_token']
+        }
+      end
 
       def endpoint_url
         "#{ENV['DEXCOM_URL']}/v2/oauth2/token"
@@ -35,6 +46,14 @@ module Partners
           grant_type: 'authorization_code',
           redirect_uri: ENV['DEXCOM_REDIRECT_URI']
         }
+      end
+
+      def response_body
+        @response_body ||= JSON.parse(@response.body)
+      end
+
+      def token
+        @token ||= Partners::Dexcom::AuthToken.instance
       end
     end
   end

--- a/app/services/partners/dexcom/auth_service.rb
+++ b/app/services/partners/dexcom/auth_service.rb
@@ -3,26 +3,20 @@
 module Partners
   module Dexcom
     class AuthService
-      attr_reader :authorization_code
+      def obtain_oauth_token(authorization_code)
+        token.authorization_code = authorization_code
 
-      def initialize(authorization_code)
-        @authorization_code = authorization_code
-      end
-
-      def obtain_oauth_token
         @response = request_auth_token
-        token_attributes = extract_auth_token
-
-        token.update_attributes!(token_attributes)
+        token.update_attributes!(auth_token_attributes)
       end
 
       private
 
       def request_auth_token
-        HTTParty.post(endpoint_url, headers: headers, body: body)
+        HTTParty.post(endpoint_url, headers: headers, body: auth_payload)
       end
 
-      def extract_auth_token
+      def auth_token_attributes
         {
           access_token: response_body['access_token'],
           expiration_time: Time.now.to_i + response_body['expires_in'].to_i,
@@ -38,14 +32,16 @@ module Partners
         { 'Content-Type': 'application/x-www-form-urlencoded' }
       end
 
-      def body
+      def base_payload
         {
           client_id: ENV['DEXCOM_CLIENT_ID'],
           client_secret: ENV['DEXCOM_CLIENT_SECRET'],
-          code: authorization_code,
-          grant_type: 'authorization_code',
           redirect_uri: ENV['DEXCOM_REDIRECT_URI']
         }
+      end
+
+      def auth_payload
+        base_payload.merge!(code: token.authorization_code, grant_type: 'authorization_code')
       end
 
       def response_body

--- a/app/services/partners/dexcom/auth_service.rb
+++ b/app/services/partners/dexcom/auth_service.rb
@@ -10,10 +10,19 @@ module Partners
         token.update_attributes!(auth_token_attributes)
       end
 
+      def renew_oauth_token
+        @response = refresh_auth_token
+        token.update_attributes!(auth_token_attributes)
+      end
+
       private
 
       def request_auth_token
         HTTParty.post(endpoint_url, headers: headers, body: auth_payload)
+      end
+
+      def refresh_auth_token
+        HTTParty.post(endpoint_url, headers: headers, body: refresh_payload)
       end
 
       def auth_token_attributes
@@ -42,6 +51,10 @@ module Partners
 
       def auth_payload
         base_payload.merge!(code: token.authorization_code, grant_type: 'authorization_code')
+      end
+
+      def refresh_payload
+        base_payload.merge!(refresh_token: token.refresh_token, grant_type: 'refresh_token')
       end
 
       def response_body

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,10 @@ Jets.application.configure do
   config.mode = "html"
 
   config.prewarm.enable = true # default is true
+  Dynamoid.configure do |config|
+    config.namespace = "#{Jets.application.config.project_name}_#{Jets.env}"
+  end
+
   # config.prewarm.rate = '30 minutes' # default is '30 minutes'
   # config.prewarm.concurrency = 2 # default is 2
   # config.prewarm.public_ratio = 3 # default is 3

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,7 +7,6 @@ Jets.application.configure do
 end
 
 Dynamoid.configure do |config|
-  config.namespace = "#{Jets.application.config.project_name}_#{Jets.env}"
   config.endpoint = 'http://localhost:6000'
   config.read_capacity = 1
   config.write_capacity = 1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,7 +9,6 @@ Jets.application.configure do
 end
 
 Dynamoid.configure do |config|
-  config.namespace = "#{Jets.application.config.project_name}_#{Jets.env}"
   config.read_capacity = 1
   config.write_capacity = 2
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,7 +7,6 @@ Jets.application.configure do
 end
 
 Dynamoid.configure do |config|
-  config.namespace = "#{Jets.application.config.project_name}_#{Jets.env}"
   config.endpoint = 'http://localhost:6000'
   config.read_capacity = 1
   config.write_capacity = 1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,5 @@
+Jets.application.routes.draw do
+  namespace :dexcom do
+    get :auth_callback, to: 'partners/dexcom/auth#auth_callback'
+  end
+end

--- a/spec/controllers/partners/dexcom/auth_controller_spec.rb
+++ b/spec/controllers/partners/dexcom/auth_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Partners::Dexcom::AuthController do
+  describe '#auth_callback' do
+    let(:authorization_code) { 'auth_code_123' }
+
+    subject { get '/dexcom/auth_callback', query: { authorization_code: authorization_code } }
+
+    it 'returns an HTTP 200 OK response' do
+      subject
+
+      expect(response.status).to eq 200
+    end
+  end
+end

--- a/spec/controllers/partners/dexcom/auth_controller_spec.rb
+++ b/spec/controllers/partners/dexcom/auth_controller_spec.rb
@@ -11,5 +11,15 @@ RSpec.describe Partners::Dexcom::AuthController do
 
       expect(response.status).to eq 200
     end
+
+    context 'when the authorization code is not present' do
+      let(:authorization_code) { nil }
+
+      it 'returns an HTTP 401 Unauthorized response' do
+        subject
+
+        expect(response.status).to eq 401
+      end
+    end
   end
 end

--- a/spec/controllers/partners/dexcom/auth_controller_spec.rb
+++ b/spec/controllers/partners/dexcom/auth_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Partners::Dexcom::AuthController do
       allow(auth_service).to receive(:obtain_oauth_token)
     end
 
-    subject { get '/dexcom/auth_callback', query: { authorization_code: authorization_code } }
+    subject { get '/dexcom/auth_callback', query: { code: authorization_code } }
 
     it 'returns an HTTP 200 OK response' do
       subject

--- a/spec/controllers/partners/dexcom/auth_controller_spec.rb
+++ b/spec/controllers/partners/dexcom/auth_controller_spec.rb
@@ -3,6 +3,12 @@
 RSpec.describe Partners::Dexcom::AuthController do
   describe '#auth_callback' do
     let(:authorization_code) { 'auth_code_123' }
+    let(:auth_service) { instance_double(Partners::Dexcom::AuthService) }
+
+    before do
+      allow(Partners::Dexcom::AuthService).to receive(:new).and_return(auth_service)
+      allow(auth_service).to receive(:obtain_oauth_token)
+    end
 
     subject { get '/dexcom/auth_callback', query: { authorization_code: authorization_code } }
 
@@ -10,6 +16,12 @@ RSpec.describe Partners::Dexcom::AuthController do
       subject
 
       expect(response.status).to eq 200
+    end
+
+    it 'obtains the OAuth token' do
+      expect(auth_service).to receive(:obtain_oauth_token)
+
+      subject
     end
 
     context 'when the authorization code is not present' do

--- a/spec/models/partners/dexcom/auth_token_spec.rb
+++ b/spec/models/partners/dexcom/auth_token_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Partners::Dexcom::AuthToken do
+  describe 'validations' do
+    it 'marks the record as valid if all the fields are present' do
+      token = described_class.new(
+        account_id: "account_id",
+        access_token: "access_token",
+        expiration_time: 1234,
+        refresh_token: "refresh_token"
+      )
+
+      expect(token).to be_valid
+    end
+
+    it 'validates presence of account_id' do
+      token = described_class.new(
+        account_id: "",
+        access_token: "access_token",
+        expiration_time: 1234,
+        refresh_token: "refresh_token"
+      )
+
+      expect(token).not_to be_valid
+    end
+
+    it 'validates presence of access_token' do
+      token = described_class.new(
+        account_id: "account_id",
+        access_token: "",
+        expiration_time: 1234,
+        refresh_token: "refresh_token"
+      )
+
+      expect(token).not_to be_valid
+    end
+
+    it 'validates presence of refresh_token' do
+      token = described_class.new(
+        account_id: "account_id",
+        access_token: "access_token",
+        expiration_time: 1234,
+        refresh_token: ""
+      )
+
+      expect(token).not_to be_valid
+    end
+  end
+end

--- a/spec/models/partners/dexcom/auth_token_spec.rb
+++ b/spec/models/partners/dexcom/auth_token_spec.rb
@@ -1,49 +1,35 @@
 # frozen_string_literal: true
 
 RSpec.describe Partners::Dexcom::AuthToken do
-  describe 'validations' do
-    it 'marks the record as valid if all the fields are present' do
-      token = described_class.new(
-        account_id: "account_id",
-        access_token: "access_token",
-        expiration_time: 1234,
-        refresh_token: "refresh_token"
-      )
+  describe '.instance' do
+    context 'if the token has not been created yet' do
+      before do
+        described_class.delete_table
+        described_class.create_table
+      end
 
-      expect(token).to be_valid
+      it 'creates a new token' do
+        expect { described_class.instance.save }.to change { described_class.count }.by(1)
+      end
     end
 
-    it 'validates presence of account_id' do
-      token = described_class.new(
-        account_id: "",
-        access_token: "access_token",
-        expiration_time: 1234,
-        refresh_token: "refresh_token"
-      )
+    context 'if a token already exists' do
+      before { described_class.instance.save }
 
-      expect(token).not_to be_valid
+      it 'always returns the same instance' do
+        expect(described_class.instance.id).to eq(described_class.instance.id)
+      end
+
+      it 'does not create new tokens' do
+        expect { described_class.instance.save }.not_to change { described_class.count }
+      end
     end
+  end
 
-    it 'validates presence of access_token' do
-      token = described_class.new(
-        account_id: "account_id",
-        access_token: "",
-        expiration_time: 1234,
-        refresh_token: "refresh_token"
-      )
-
-      expect(token).not_to be_valid
-    end
-
-    it 'validates presence of refresh_token' do
-      token = described_class.new(
-        account_id: "account_id",
-        access_token: "access_token",
-        expiration_time: 1234,
-        refresh_token: ""
-      )
-
-      expect(token).not_to be_valid
+  describe '.new' do
+    it 'is marked as private' do
+      skip 'Dynamoid calls .new when doing first, last and other methods; look for a workaround'
+      expect { described_class.new }.to raise_error(NoMethodError)
     end
   end
 end

--- a/spec/services/partners/dexcom/auth_service_spec.rb
+++ b/spec/services/partners/dexcom/auth_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Partners::Dexcom::AuthService do
-  describe '#obtain_oauth_token' do
     let(:mock_dexcom_credentials) do
       {
         DEXCOM_URL: 'https://api.dexcom.com',
@@ -12,22 +11,11 @@ RSpec.describe Partners::Dexcom::AuthService do
     end
 
     let(:mock_headers) { { 'Content-Type' => 'application/x-www-form-urlencoded' } }
-    let(:mock_request_body) do
+    let(:base_payload) do
       {
         client_id: 'client_id',
         client_secret: 'client_secret',
-        code: '1234',
-        grant_type: 'authorization_code',
         redirect_uri: 'www.example.com/dexcom'
-      }
-    end
-
-    let(:mock_response) do
-      {
-        'access_token': 'example_access_token',
-        'expires_in': 7200,
-        'token_type': 'Bearer',
-        'refresh_token': 'example_refresh_token'
       }
     end
 
@@ -42,6 +30,24 @@ RSpec.describe Partners::Dexcom::AuthService do
     around { |example| with_modified_env(mock_dexcom_credentials) { example.run } }
 
     after { travel_back }
+
+  describe '#obtain_oauth_token' do
+    let(:mock_request_body) { base_payload.merge(code: '1234', grant_type: 'authorization_code') }
+
+    let(:mock_response) do
+      {
+        'access_token': 'example_access_token',
+        'expires_in': 7200,
+        'token_type': 'Bearer',
+        'refresh_token': 'example_refresh_token'
+      }
+    end
+
+    before do
+      @stub = stub_request(:post, 'https://api.dexcom.com/v2/oauth2/token')
+              .with(headers: mock_headers, body: mock_request_body)
+              .to_return(status: 200, body: mock_response.to_json)
+    end
 
     subject { described_class.new.obtain_oauth_token('1234') }
 
@@ -58,6 +64,43 @@ RSpec.describe Partners::Dexcom::AuthService do
         access_token: 'example_access_token',
         expiration_time: Time.new(2018, 10, 30, 14, 34, 56).to_i,
         refresh_token: 'example_refresh_token'
+      }
+      expect(token).to have_attributes expected_attributes
+    end
+  end
+
+  describe '#renew_oauth_token' do
+    let(:mock_request_body) { base_payload.merge(refresh_token: '5678', grant_type: 'refresh_token') }
+
+    let(:mock_response) do
+      {
+        'access_token': 'example_new_access_token',
+        'expires_in': 3600,
+        'token_type': 'Bearer',
+        'refresh_token': 'example_new_refresh_token'
+      }
+    end
+
+    before do
+      Partners::Dexcom::AuthToken.instance
+      .update_attributes(refresh_token: '5678')
+    end
+
+    subject { described_class.new.renew_oauth_token }
+
+    it 'requests the token renewal to Dexcom' do
+      subject
+
+      expect(@stub).to have_been_requested
+    end
+
+    it 'stores the renewed token information' do
+      token = subject
+
+      expected_attributes = {
+        access_token: 'example_new_access_token',
+        expiration_time: Time.new(2018, 10, 30, 13, 34, 56).to_i,
+        refresh_token: 'example_new_refresh_token'
       }
       expect(token).to have_attributes expected_attributes
     end

--- a/spec/services/partners/dexcom/auth_service_spec.rb
+++ b/spec/services/partners/dexcom/auth_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe Partners::Dexcom::AuthService do
+  describe '#obtain_oauth_token' do
+    let(:mock_dexcom_credentials) do
+      {
+        DEXCOM_URL: 'https://api.dexcom.com',
+        DEXCOM_CLIENT_ID: 'client_id',
+        DEXCOM_CLIENT_SECRET: 'client_secret',
+        DEXCOM_REDIRECT_URI: 'www.example.com/dexcom'
+      }
+    end
+
+    let(:mock_headers) { { 'Content-Type' => 'application/x-www-form-urlencoded' } }
+    let(:mock_request_body) do
+      {
+        client_id: 'client_id',
+        client_secret: 'client_secret',
+        code: '1234',
+        grant_type: 'authorization_code',
+        redirect_uri: 'www.example.com/dexcom'
+      }
+    end
+
+    let(:mock_response) do
+      {
+        'access_token': 'example_access_token',
+        'expires_in': 7200,
+        'token_type': 'Bearer',
+        'refresh_token': 'example_refresh_token'
+      }
+    end
+
+    before do
+      @stub = stub_request(:post, 'https://api.dexcom.com/v2/oauth2/token')
+              .with(headers: mock_headers, body: mock_request_body)
+              .to_return(status: 200, body: mock_response.to_json)
+    end
+
+    around { |example| with_modified_env(mock_dexcom_credentials) { example.run } }
+
+    subject { described_class.new('1234') }
+
+    it 'requests the access token to Dexcom' do
+      subject.obtain_oauth_token
+
+      expect(@stub).to have_been_requested
+    end
+
+    it 'stores the access token information'
+  end
+end

--- a/spec/services/partners/dexcom/auth_service_spec.rb
+++ b/spec/services/partners/dexcom/auth_service_spec.rb
@@ -43,16 +43,16 @@ RSpec.describe Partners::Dexcom::AuthService do
 
     after { travel_back }
 
-    subject { described_class.new('1234') }
+    subject { described_class.new.obtain_oauth_token('1234') }
 
     it 'requests the access token to Dexcom' do
-      subject.obtain_oauth_token
+      subject
 
       expect(@stub).to have_been_requested
     end
 
     it 'stores the access token information' do
-      token = subject.obtain_oauth_token
+      token = subject
 
       expected_attributes = {
         access_token: 'example_access_token',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "byebug"
 require "fileutils"
 require "jets"
 require 'webmock/rspec'
+require 'active_support/testing/time_helpers'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -21,6 +22,8 @@ RSpec.configure do |c|
   c.before(:each) do
     DynamoidReset.all
   end
+
+  c.include ActiveSupport::Testing::TimeHelpers
 end
 
 def with_modified_env(options, &block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ ENV['HOME'] = "spec/fixtures/home"
 require "byebug"
 require "fileutils"
 require "jets"
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 abort("The Jets environment is running in production mode!") if Jets.env == "production"
 Jets.boot
@@ -18,4 +21,8 @@ RSpec.configure do |c|
   c.before(:each) do
     DynamoidReset.all
   end
+end
+
+def with_modified_env(options, &block)
+  ClimateControl.modify(options, &block)
 end


### PR DESCRIPTION
## What?
In order to use Dexcom data in our services, we need to integrate with their API. This PR includes the logic that handles the first part of this process, the authentication against their services. The process can be described in more detail in [their documentation](https://developer.dexcom.com/authentication) and consists of the following steps:

1. Specifying a callback URL to which they will send the user authorization code will be send
2. Using that auth code to request an OAuth access code
3. When that access code expires, refresh it

## How?
We have divided the change in several parts

1. Creating a controller, `Partners::Dexcom::AuthController`, that will be the callback for the auth process
2. Creating a model, `Partners::Dexcom::AuthToken`, that represents an authentication token with the information returned by Dexcom. This model will be a Singleton object, because we only need one token to be working at the same time
3. Creating a service, `Partners::Dexcom::AuthService`, that includes the business logic related with the Dexcom authentication (obtaining a token, renewing it, etc).