### PR TITLE
Publishing injection metrics to CloudWatch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "jets", "<= 1.9.30"
 gem 'climate_control'
 gem "dynamoid"
 gem "httparty"
+gem 'aws-sdk-cloudwatch'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
     aws-sdk-cloudformation (1.24.0)
       aws-sdk-core (~> 3, >= 3.58.0)
       aws-sigv4 (~> 1.1)
+    aws-sdk-cloudwatch (1.26.0)
+      aws-sdk-core (~> 3, >= 3.58.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-cloudwatchlogs (1.23.0)
       aws-sdk-core (~> 3, >= 3.58.0)
       aws-sigv4 (~> 1.1)
@@ -234,6 +237,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-cloudwatch
   byebug
   climate_control
   dynamoid

--- a/app/jobs/health/create_injection_job.rb
+++ b/app/jobs/health/create_injection_job.rb
@@ -2,16 +2,24 @@
 
 module Health
   class CreateInjectionJob < ::ApplicationJob
-    sns_event 'InsulinInjected'
 
+    sns_event 'InsulinInjected'
     def create_injection
       injection_information = Health::InjectionParser.new(event).parse
 
-      Health::Injection.create!(
+      injection = Health::Injection.create!(
         units: injection_information[:units],
         injection_type: injection_information[:injection_type],
         notes: injection_information[:notes]
       )
+
+      publish_injection_metric(injection)
+    end
+
+    private
+
+    def publish_injection_metric(injection)
+      AwsServices::CloudwatchWrapper.new.publish_injection(injection)
     end
   end
 end

--- a/app/services/aws_services/cloudwatch_wrapper.rb
+++ b/app/services/aws_services/cloudwatch_wrapper.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AwsServices
+  class CloudwatchWrapper
+    attr_reader :client
+
+    def initialize
+      @client = Aws::CloudWatch::Client.new
+    end
+
+    def publish_injection(injection)
+      client.put_metric_data(
+        namespace: 'Health',
+        metric_data: [{
+          metric_name: 'Insulin',
+          dimensions: [{
+            name: 'Type',
+            value: injection.injection_type
+          }],
+          timestamp: injection.created_at,
+          value: injection.units.to_f,
+          unit: 'Count'
+        }]
+      )
+    end
+  end
+end


### PR DESCRIPTION
### What?
In order to have a better visibility of the insulin injections, we will start publishing them into CloudWatch. They will be treated as if they were any other type of metric, and therefore we'll be able to create check historic metrics, create Dashboards, etc

We'll treat both types of injections as the same metric, but having different dimensions (in this case, the differentiating one will be the "Type" dimension). The value that we'll publish will be the amount of units of the injection

### How?
Creating a class to act as a wrapper to CloudWatch, and adding a method to
specifically publish an injection. This method contains all the logic about
what information should be published, which Namespace we'll be using, which
dimensions and units, etc.

Then we added extra logic in CreateInjectionJob to publish the injection metric 
after we create it.