### PR TITLE
Expenses

### DIFF
--- a/app/jobs/finance/create_expense_job.rb
+++ b/app/jobs/finance/create_expense_job.rb
@@ -12,6 +12,16 @@ module Finance
         category: expense_information[:category],
         notes: expense_information[:notes]
       )
+
+      publish_expense_metric(expense)
+
+      expense
+    end
+
+    private
+
+    def publish_expense_metric(expense)
+      AwsServices::CloudwatchWrapper.new.publish_expense(expense)
     end
   end
 end

--- a/app/jobs/finance/create_expense_job.rb
+++ b/app/jobs/finance/create_expense_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Finance
+  class CreateExpenseJob < ::ApplicationJob
+    sns_event 'MoneySpent'
+
+    def create_expense
+      expense_information = Finance::ExpenseParser.new(event).parse
+
+      expense = Finance::Expense.create!(
+        amount: expense_information[:amount],
+        category: expense_information[:category],
+        notes: expense_information[:notes]
+      )
+    end
+  end
+end

--- a/app/models/finance/expense.rb
+++ b/app/models/finance/expense.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Finance
+  class Expense
+    include Dynamoid::Document
+
+    field :amount, :number
+    field :category, :string
+    field :notes, :string
+
+    validates_presence_of :amount
+    validates_presence_of :category
+  end
+end

--- a/app/parsers/finance/expense_parser.rb
+++ b/app/parsers/finance/expense_parser.rb
@@ -1,0 +1,11 @@
+module Finance
+  class ExpenseParser < SnsParser
+    def parse
+      {
+        amount: event[:amount].to_f,
+        category: event[:category],
+        notes: event[:notes]
+      }
+    end
+  end
+end

--- a/app/services/aws_services/cloudwatch_wrapper.rb
+++ b/app/services/aws_services/cloudwatch_wrapper.rb
@@ -23,5 +23,20 @@ module AwsServices
         }]
       )
     end
+
+    def publish_expense(expense)
+      client.put_metric_data(
+        namespace: 'Finance',
+        metric_data: [{
+          metric_name: 'Money spent',
+          timestamp: expense.created_at,
+          dimensions: [{
+            name: 'Category',
+            value: expense.category
+          }],
+          value: expense.amount
+        }]
+      )
+    end
   end
 end

--- a/app/services/aws_services/cloudwatch_wrapper.rb
+++ b/app/services/aws_services/cloudwatch_wrapper.rb
@@ -34,7 +34,7 @@ module AwsServices
             name: 'Category',
             value: expense.category
           }],
-          value: expense.amount
+          value: expense.amount.to_f
         }]
       )
     end

--- a/spec/fixtures/sns_events/finance/MoneySpent.json
+++ b/spec/fixtures/sns_events/finance/MoneySpent.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-1:598877714121:MoneySpent:bb252d77-c541-46c0-8a9e-5ba5aa45ee35",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "9d044cb2-0d73-5525-a38e-19048502e12c",
+        "TopicArn": "arn:aws:sns:eu-west-1:598877714121:MoneySpent",
+        "Subject": null,
+        "Message": "{\"amount\": 42.24, \"category\": \"eating out\", \"notes\": \"Expense testing notes\"}",
+        "Timestamp": "2019-07-27T17:13:21.905Z",
+        "SignatureVersion": "1",
+        "Signature": "DHe9GXILX41drnka/cgWVHFgO/+1Y39n0ERJzfSB/NoHE4K53DpdOrFC1tZUX/polhjgVL8XEZMoWC/p5mxv5di6vbqRqpyErldvKU3Maz6X06MKNoPlHUgeTRIruUa4Nd0tT049x5Chbym1AiK1a+/XTII0+UNk4SfEKuvMW4rlH3saRezWXKgUHhV3LuxhcAVpjQ0jdpvHxZqPTBCMe4dfY5RWCdHxHF83aAOEGJvjuoOoTmqnc1XGIJXTzQEBukBsD5ePIyTrWeZzVV+JJL7VpvEr26syasa7bgz6/qTa4AKjuu5GEZ2zR1J90C8DQJ1Ev1BJxZIFywWq0OsuSQ==",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe\\u0026SubscriptionArn=arn:aws:sns:eu-west-1:598877714121:MoneySpent:bb252d77-c541-46c0-8a9e-5ba5aa45ee35",
+        "MessageAttributes": {}
+      }
+    }
+  ]
+}

--- a/spec/jobs/finance/create_expense_job_spec.rb
+++ b/spec/jobs/finance/create_expense_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::CreateExpenseJob do
+  describe 'create_expense' do
+    let(:event) { JSON.parse(File.read('spec/fixtures/sns_events/finance/MoneySpent.json')) }
+
+    subject { described_class.perform_now(:create_expense, event) }
+
+    it 'creates a new expense' do
+      expect { subject }.to change { Finance::Expense.all.count }.by 1
+    end
+
+    it 'returns the expense' do
+      expect(subject).to be_a_kind_of Finance::Expense
+    end
+
+    it 'sets the expense attributes correctly' do
+      expense = subject
+
+      expect(expense.amount).to eq 42.24
+      expect(expense.category).to eq 'eating out'
+      expect(expense.notes).to eq 'Expense testing notes'
+    end
+  end
+end

--- a/spec/parsers/finance/expense_parser_spec.rb
+++ b/spec/parsers/finance/expense_parser_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::ExpenseParser do
+  let(:parser) { described_class.new(sns_event) }
+
+  describe '#parse' do
+    let(:sns_event) { JSON.parse(File.read('spec/fixtures/sns_events/finance/MoneySpent.json')) }
+
+    subject { parser.parse }
+
+    it 'returns a hash with the expense information' do
+      expected_expense = { amount: 42.24, category: 'eating out', notes: 'Expense testing notes' }
+
+      expect(subject).to eq expected_expense
+    end
+  end
+end

--- a/spec/services/aws_services/cloudwatch_wrapper_spec.rb
+++ b/spec/services/aws_services/cloudwatch_wrapper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe AwsServices::CloudwatchWrapper do
+  let(:metrics_service) { instance_double(Aws::CloudWatch::Client) }
+
+  before { allow(Aws::CloudWatch::Client).to receive(:new).and_return metrics_service }
+
+  describe '#publish_expense' do
+    before { allow(metrics_service).to receive(:put_metric_data) }
+
+    it 'publishes the expense in CloudWatch' do
+      expense = Finance::Expense.new(amount: 42, category: 'eating out', notes: 'test expense note')
+      expected_metric_data = {
+        namespace: 'Finance',
+        metric_data: [{
+          metric_name: 'Money spent',
+          timestamp: expense.created_at,
+          dimensions: [{
+            name: 'Category',
+            value: 'eating out'
+          }],
+          value: 42.0
+        }]
+      }
+
+      expect(metrics_service).to receive(:put_metric_data).with(expected_metric_data)
+      AwsServices::CloudwatchWrapper.new.publish_expense(expense)
+    end
+  end
+end


### PR DESCRIPTION
### Description
This PR adds the possibility of tracking expenses. The flow is very similar to the one that we have currently in place for Injections:

1) The SNS topic `MoneySpent` gets a publication
2) A job is triggered by published event
3) The job creates a Expense and saves it + publishes a metric with its information in CloudWatch

### Implementation
Once again, the implementation details are very similar to the ones that we have for Injection:

1) **`Finance::Expense` model**: represents an expense. Has the fields "amount", "category" and "notes"
2) **Finance::ExpenseParser**: parses the SNS event and returns a hash with the expense fields
3) **CreateExpenseJob**: the orchestrator. Is triggered by the SNS event and parses it, creates the expense object and publishes the metric in CloudWatch
