### PR TITLE
Integrating with YNAB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'climate_control'
 gem "dynamoid"
 gem "httparty"
 gem 'aws-sdk-cloudwatch'
+gem 'ynab'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
       concurrent-ruby (>= 1.0)
       null-logger
     erubi (1.8.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
+    ffi (1.11.3)
     gems (1.1.1)
       json
     globalid (0.4.2)
@@ -224,6 +227,8 @@ GEM
     text-table (1.2.4)
     thor (0.20.3)
     thread_safe (0.3.6)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -231,6 +236,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    ynab (1.15.0)
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
     zeitwerk (2.1.10)
 
 PLATFORMS
@@ -250,6 +258,7 @@ DEPENDENCIES
   rubocop
   shotgun
   webmock
+  ynab
 
 BUNDLED WITH
    2.0.2

--- a/app/jobs/finance/create_expense_job.rb
+++ b/app/jobs/finance/create_expense_job.rb
@@ -14,6 +14,7 @@ module Finance
       )
 
       publish_expense_metric(expense)
+      publish_expense_in_ynab(expense)
 
       expense
     end
@@ -22,6 +23,13 @@ module Finance
 
     def publish_expense_metric(expense)
       AwsServices::CloudwatchWrapper.new.publish_expense(expense)
+    end
+
+    def publish_expense_in_ynab(expense)
+      ynab = YNAB::API.new(ENV['YNAB_TOKEN'])
+
+      data = { transaction: Ynab::TransactionData.from_expense(expense).to_h }
+      ynab.transactions.create_transaction(Ynab::Budgets::BUDGET_ID, data)
     end
   end
 end

--- a/app/services/ynab/accounts.rb
+++ b/app/services/ynab/accounts.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ynab
+  module Accounts
+    AIB = 'AIB'
+    BANKIA = 'Bankia'
+    OPENBANK = 'Openbank'
+
+    DEFAULT = AIB
+
+    ACCOUNT_IDS = {
+      AIB => 'e1a73ac1-62aa-4c12-a012-040982104623',
+      BANKIA => '8c36cf6d-fac1-4517-a501-7287955d8706',
+      OPENBANK => 'ba3e4149-19e0-404d-a5c1-2c1878005ac6'
+    }
+
+    def self.get_id(account = nil)
+      ACCOUNT_IDS[account] || ACCOUNT_IDS[DEFAULT]
+    end
+  end
+end

--- a/app/services/ynab/budgets.rb
+++ b/app/services/ynab/budgets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Ynab
+  module Budgets
+    BUDGET_ID = '5c2bebb8-3fc4-4393-95c6-288daeba7898'
+  end
+end

--- a/app/services/ynab/categories.rb
+++ b/app/services/ynab/categories.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ynab
+  module Categories
+    COCA_COLA = 'coca cola'
+    EATING_OUT = 'eating out'
+    FUN = 'fun money'
+    SUPERMARKET = 'supermercado'
+
+    UNCATEGORIZED_CATEGORY_ID = 'e172c064-eb5c-4fb2-9bd7-ae5fe9af692f'
+
+    CATEGORY_IDS = {
+      COCA_COLA => '2acef0a6-0432-412b-91a4-45d68eb6efc4',
+      EATING_OUT => 'f8ba8264-2699-49b4-b233-1fca11788721',
+      FUN => 'e84c51bf-3739-4212-b0b0-496839f90d76',
+      SUPERMARKET => 'bce9fcf8-7a1f-46b2-af2c-4b998ac4785b'
+    }.freeze
+  end
+end

--- a/app/services/ynab/transaction_data.rb
+++ b/app/services/ynab/transaction_data.rb
@@ -1,0 +1,20 @@
+module Ynab
+  class TransactionData
+    CENTS_PER_EURO = 100
+
+    attr_accessor :account_id, :amount, :approved, :category_id, :date, :memo
+
+    def self.from_expense(expense)
+      transaction = new
+
+      transaction.amount = expense.amount * CENTS_PER_EURO
+      transaction.date = expense.created_at.to_date.iso8601
+      transaction.memo = expense.notes
+      transaction.category_id = Ynab::Categories::CATEGORY_IDS[expense.category] || Ynab::Categories::UNCATEGORIZED_CATEGORY_ID
+      transaction.account_id = Ynab::Accounts::ACCOUNT_IDS[Ynab::Accounts::DEFAULT]
+      transaction.approved = true
+
+      transaction
+    end
+  end
+end

--- a/app/services/ynab/transaction_data.rb
+++ b/app/services/ynab/transaction_data.rb
@@ -16,5 +16,15 @@ module Ynab
 
       transaction
     end
+
+    def to_h
+      {
+        account_id: account_id,
+        amount: amount,
+        category_id: category_id,
+        date: date,
+        memo: memo
+      }
+    end
   end
 end

--- a/app/services/ynab/transaction_data.rb
+++ b/app/services/ynab/transaction_data.rb
@@ -1,18 +1,18 @@
 module Ynab
   class TransactionData
-    CENTS_PER_EURO = 100
+    MILIUNITS_PER_EURO = 1000
+    CONVERT_TO_EXPENSE = -1
 
-    attr_accessor :account_id, :amount, :approved, :category_id, :date, :memo
+    attr_accessor :account_id, :amount, :category_id, :date, :memo
 
     def self.from_expense(expense)
       transaction = new
 
-      transaction.amount = expense.amount * CENTS_PER_EURO
+      transaction.amount = (expense.amount * MILIUNITS_PER_EURO * CONVERT_TO_EXPENSE).to_i
       transaction.date = expense.created_at.to_date.iso8601
       transaction.memo = expense.notes
       transaction.category_id = Ynab::Categories::CATEGORY_IDS[expense.category] || Ynab::Categories::UNCATEGORIZED_CATEGORY_ID
       transaction.account_id = Ynab::Accounts::ACCOUNT_IDS[Ynab::Accounts::DEFAULT]
-      transaction.approved = true
 
       transaction
     end

--- a/spec/jobs/finance/create_expense_job_spec.rb
+++ b/spec/jobs/finance/create_expense_job_spec.rb
@@ -4,12 +4,16 @@ RSpec.describe Finance::CreateExpenseJob do
   describe 'create_expense' do
     let(:event) { JSON.parse(File.read('spec/fixtures/sns_events/finance/MoneySpent.json')) }
     let(:mock_cw) { instance_double(AwsServices::CloudwatchWrapper) }
+    let(:mock_ynab) { instance_double(YNAB::API) }
 
     subject { described_class.perform_now(:create_expense, event) }
 
     before do
       allow(AwsServices::CloudwatchWrapper).to receive(:new).and_return(mock_cw)
       allow(mock_cw).to receive(:publish_expense).and_return({})
+
+      allow(YNAB::API).to receive(:new).and_return(mock_ynab)
+      allow(mock_ynab).to receive_message_chain(:transactions, :create_transaction)
     end
 
     it 'creates a new expense' do
@@ -30,6 +34,12 @@ RSpec.describe Finance::CreateExpenseJob do
 
     it 'publishes the expense in CloudWatch' do
       expect(mock_cw).to receive(:publish_expense)
+
+      subject
+    end
+
+    it 'publishes the expense in YNAB' do
+      expect(mock_ynab).to receive_message_chain(:transactions, :create_transaction)
 
       subject
     end

--- a/spec/services/ynab/transaction_data_spec.rb
+++ b/spec/services/ynab/transaction_data_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Ynab::TransactionData do
     before { expense.save }
 
     it('sets the YNAB account_id') { expect(transaction.account_id).to eq default_account_id }
-    it('sets the transaction amount in cents') { expect(transaction.amount).to eq 4224 }
+    it('sets the transaction amount in negative miliunits') { expect(transaction.amount).to eq -42240 }
     it('sets the transaction date') { expect(transaction.date).to eq Date.today.strftime('%Y-%m-%d') }
     it('sets the memo') { expect(transaction.memo).to eq 'Expense for testing' }
     it('sets the category id') { expect(transaction.category_id).to eq 'f8ba8264-2699-49b4-b233-1fca11788721' }

--- a/spec/services/ynab/transaction_data_spec.rb
+++ b/spec/services/ynab/transaction_data_spec.rb
@@ -1,19 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe Ynab::TransactionData do
-  describe '.from_expense' do
-    let(:expense) { Finance::Expense.new(amount: 42.24, notes: 'Expense for testing', category: 'eating out') }
-    let(:default_account_id) { 'e1a73ac1-62aa-4c12-a012-040982104623' }
+  let(:expense) { Finance::Expense.new(amount: 42.24, notes: 'Expense for testing', category: 'eating out') }
+  let(:default_account_id) { 'e1a73ac1-62aa-4c12-a012-040982104623' }
+  let(:eating_out_category_id) { 'f8ba8264-2699-49b4-b233-1fca11788721' }
 
+  describe '.from_expense' do
     subject(:transaction) { Ynab::TransactionData.from_expense(expense) }
 
     before { expense.save }
 
     it('sets the YNAB account_id') { expect(transaction.account_id).to eq default_account_id }
-    it('sets the transaction amount in negative miliunits') { expect(transaction.amount).to eq -42240 }
+    it('sets the transaction amount in negative miliunits') { expect(transaction.amount).to eq -42_240 }
     it('sets the transaction date') { expect(transaction.date).to eq Date.today.strftime('%Y-%m-%d') }
     it('sets the memo') { expect(transaction.memo).to eq 'Expense for testing' }
-    it('sets the category id') { expect(transaction.category_id).to eq 'f8ba8264-2699-49b4-b233-1fca11788721' }
+    it('sets the category id') { expect(transaction.category_id).to eq eating_out_category_id }
 
     context 'when the category is invalid' do
       let(:expense) { Finance::Expense.new(amount: 42.0, notes: 'Expense for testing', category: 'Something random') }
@@ -22,6 +23,34 @@ RSpec.describe Ynab::TransactionData do
       it 'sets the transaction as "Uncategorized"' do
         expect(transaction.category_id).to eq uncategorized_category_id
       end
+    end
+  end
+
+  describe '#to_h' do
+    let(:amount) { -42_240 }
+    let(:notes) { 'Transaction for testing' }
+    let(:date) { Date.today.strftime('%Y-%m-%d') }
+
+    let(:transaction) { Ynab::TransactionData.new }
+
+    before do
+      transaction.amount = amount
+      transaction.memo = notes
+      transaction.category_id = eating_out_category_id
+      transaction.account_id = default_account_id
+      transaction.date = date
+    end
+
+    subject { transaction.to_h }
+
+    it { expect(subject[:amount]).to eq transaction.amount }
+    it { expect(subject[:category_id]).to eq transaction.category_id }
+    it { expect(subject[:account_id]).to eq transaction.account_id }
+    it { expect(subject[:memo]).to eq transaction.memo }
+    it { expect(subject[:date]).to eq transaction.date }
+
+    it 'has the correct keys' do
+      expect(subject.keys).to contain_exactly(:amount, :category_id, :account_id, :memo, :date)
     end
   end
 end

--- a/spec/services/ynab/transaction_data_spec.rb
+++ b/spec/services/ynab/transaction_data_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Ynab::TransactionData do
+  describe '.from_expense' do
+    let(:expense) { Finance::Expense.new(amount: 42.24, notes: 'Expense for testing', category: 'eating out') }
+    let(:default_account_id) { 'e1a73ac1-62aa-4c12-a012-040982104623' }
+
+    subject(:transaction) { Ynab::TransactionData.from_expense(expense) }
+
+    before { expense.save }
+
+    it('sets the YNAB account_id') { expect(transaction.account_id).to eq default_account_id }
+    it('sets the transaction amount in cents') { expect(transaction.amount).to eq 4224 }
+    it('sets the transaction date') { expect(transaction.date).to eq Date.today.strftime('%Y-%m-%d') }
+    it('sets the memo') { expect(transaction.memo).to eq 'Expense for testing' }
+    it('sets the category id') { expect(transaction.category_id).to eq 'f8ba8264-2699-49b4-b233-1fca11788721' }
+
+    context 'when the category is invalid' do
+      let(:expense) { Finance::Expense.new(amount: 42.0, notes: 'Expense for testing', category: 'Something random') }
+      let(:uncategorized_category_id) { 'e172c064-eb5c-4fb2-9bd7-ae5fe9af692f' }
+
+      it 'sets the transaction as "Uncategorized"' do
+        expect(transaction.category_id).to eq uncategorized_category_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What?
Integrating with YNAB (You Need A Budget) in order to add expenses there automatically. Currently, the action is executed when an expense is created, exactly after publishing it in CloudWatch 

### How?
We use the official [YNAB SDK for Ruby](https://github.com/ynab/ynab-sdk-ruby).

In order to represent the transactions that will be created, we have the class `Ynab::TransactionData` and three helper modules: `Ynab::Accounts`, `Ynab::Budgets` and `Ynab::Categories`

With the class method `Ynab::TransactionData.from_expense` we extract data from a `Finance::Expense` object and build a `Ynab::TransactionData` from it. Then, in `CreateExpenseJob` we send this information to YNAB. 