### PR TITLE
Integrating with Airtable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "dynamoid"
 gem "httparty"
 gem 'aws-sdk-cloudwatch'
 gem 'ynab'
+gem 'airrecord'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    airrecord (1.0.3)
+      faraday (~> 0.10)
+      net-http-persistent (>= 2.9)
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
@@ -89,6 +92,7 @@ GEM
     cfnresponse (0.4.0)
     climate_control (0.2.0)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
@@ -102,6 +106,8 @@ GEM
     erubi (1.8.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
+    faraday (0.17.3)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
     gems (1.1.1)
       json
@@ -173,6 +179,9 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    net-http-persistent (3.1.0)
+      connection_pool (~> 2.2)
     nio4r (2.5.2)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
@@ -245,6 +254,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airrecord
   aws-sdk-cloudwatch
   byebug
   climate_control

--- a/app/jobs/finance/create_expense_job.rb
+++ b/app/jobs/finance/create_expense_job.rb
@@ -14,6 +14,7 @@ module Finance
       )
 
       publish_expense_metric(expense)
+      publish_expense_in_airtable(expense)
       publish_expense_in_ynab(expense)
 
       expense
@@ -23,6 +24,10 @@ module Finance
 
     def publish_expense_metric(expense)
       AwsServices::CloudwatchWrapper.new.publish_expense(expense)
+    end
+
+    def publish_expense_in_airtable(expense)
+      Airtable::Expense.from_expense(expense)
     end
 
     def publish_expense_in_ynab(expense)

--- a/app/models/finance/expense_categories.rb
+++ b/app/models/finance/expense_categories.rb
@@ -1,0 +1,8 @@
+module Finance
+  module ExpenseCategories
+    COCA_COLA = 'coca cola'
+    EATING_OUT = 'eating out'
+    FUN = 'fun money'
+    SUPERMARKET = 'supermercado'
+  end
+end

--- a/app/services/airtable/categories.rb
+++ b/app/services/airtable/categories.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Airtable
+  module Categories
+    BAR_RESTAURANT = 'Bar / Restaurant'
+    FUN = 'Ocio'
+    SUPERMARKET = 'Supermercado'
+
+    MAPPING = {
+      Finance::ExpenseCategories::COCA_COLA => BAR_RESTAURANT,
+      Finance::ExpenseCategories::EATING_OUT => BAR_RESTAURANT,
+      Finance::ExpenseCategories::FUN => FUN,
+      Finance::ExpenseCategories::SUPERMARKET => SUPERMARKET
+    }.freeze
+  end
+end

--- a/app/services/airtable/expense.rb
+++ b/app/services/airtable/expense.rb
@@ -2,7 +2,8 @@
 
 module Airtable
   class Expense < Airrecord::Table
-    self.table_name = 'Expense Tracking'
+    self.base_key = 'appxOlf4rvMwaYk4K'
+    self.table_name = 'Receipt Log'
 
     ATTRIBUTE_TO_COLUMN = {
       'amount' => 'Total',
@@ -14,10 +15,12 @@ module Airtable
     def self.from_expense(finance_expense)
       expense = new({})
 
-      expense.amount = finance_expense.amount
+      expense.amount = finance_expense.amount.to_f
       expense.category = Airtable::Categories::MAPPING[finance_expense.category]
       expense.datetime = finance_expense.created_at.iso8601
       expense.title = finance_expense.notes
+
+      expense.save
 
       expense
     end

--- a/app/services/airtable/expense.rb
+++ b/app/services/airtable/expense.rb
@@ -4,11 +4,12 @@ module Airtable
   class Expense < Airrecord::Table
     self.table_name = 'Expense Tracking'
 
-    # Column names
-    AMOUNT = 'Total'
-    CATEGORY = 'Category'
-    DATETIME = 'Date & Time'
-    TITLE = 'Short Description'
+    ATTRIBUTE_TO_COLUMN = {
+      'amount' => 'Total',
+      'category' => 'Category',
+      'datetime' => 'Date & Time',
+      'title' => 'Short Description'
+    }.freeze
 
     def self.from_expense(finance_expense)
       expense = new({})
@@ -21,36 +22,16 @@ module Airtable
       expense
     end
 
-    def amount
-      self[AMOUNT]
-    end
+    ATTRIBUTE_TO_COLUMN.keys.each do |attribute|
+      column = ATTRIBUTE_TO_COLUMN[attribute]
 
-    def amount=(value)
-      self[AMOUNT] = value
-    end
+      define_method("#{attribute}") do
+        self[column]
+      end
 
-    def category
-      self[CATEGORY]
-    end
-
-    def category=(value)
-      self[CATEGORY] = value
-    end
-
-    def datetime
-      self[DATETIME]
-    end
-
-    def datetime=(value)
-      self[DATETIME] = value
-    end
-
-    def title
-      self[TITLE]
-    end
-
-    def title=(value)
-      self[TITLE] = value
+      define_method("#{attribute}=") do |value|
+        self[column] = value
+      end
     end
   end
 end

--- a/app/services/airtable/expense.rb
+++ b/app/services/airtable/expense.rb
@@ -14,6 +14,7 @@ module Airtable
       expense = new({})
 
       expense.amount = finance_expense.amount
+      expense.category = Airtable::Categories::MAPPING[finance_expense.category]
       expense.datetime = finance_expense.created_at.iso8601
       expense.title = finance_expense.notes
 

--- a/app/services/airtable/expense.rb
+++ b/app/services/airtable/expense.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Airtable
+  class Expense < Airrecord::Table
+    self.table_name = 'Expense Tracking'
+
+    # Column names
+    AMOUNT = 'Total'
+    CATEGORY = 'Category'
+    DATETIME = 'Date & Time'
+    TITLE = 'Short Description'
+
+    def self.from_expense(finance_expense)
+      expense = new({})
+
+      expense.amount = finance_expense.amount
+      expense.datetime = finance_expense.created_at.iso8601
+      expense.title = finance_expense.notes
+
+      expense
+    end
+
+    def amount
+      self[AMOUNT]
+    end
+
+    def amount=(value)
+      self[AMOUNT] = value
+    end
+
+    def category
+      self[CATEGORY]
+    end
+
+    def category=(value)
+      self[CATEGORY] = value
+    end
+
+    def datetime
+      self[DATETIME]
+    end
+
+    def datetime=(value)
+      self[DATETIME] = value
+    end
+
+    def title
+      self[TITLE]
+    end
+
+    def title=(value)
+      self[TITLE] = value
+    end
+  end
+end

--- a/app/services/ynab/categories.rb
+++ b/app/services/ynab/categories.rb
@@ -2,18 +2,18 @@
 
 module Ynab
   module Categories
-    COCA_COLA = 'coca cola'
-    EATING_OUT = 'eating out'
-    FUN = 'fun money'
-    SUPERMARKET = 'supermercado'
+    COCA_COLA_ID = '2acef0a6-0432-412b-91a4-45d68eb6efc4'
+    EATING_OUT_ID = 'f8ba8264-2699-49b4-b233-1fca11788721'
+    FUN_ID = 'e84c51bf-3739-4212-b0b0-496839f90d76'
+    SUPERMARKET_ID = 'bce9fcf8-7a1f-46b2-af2c-4b998ac4785b'
 
     UNCATEGORIZED_CATEGORY_ID = 'e172c064-eb5c-4fb2-9bd7-ae5fe9af692f'
 
     CATEGORY_IDS = {
-      COCA_COLA => '2acef0a6-0432-412b-91a4-45d68eb6efc4',
-      EATING_OUT => 'f8ba8264-2699-49b4-b233-1fca11788721',
-      FUN => 'e84c51bf-3739-4212-b0b0-496839f90d76',
-      SUPERMARKET => 'bce9fcf8-7a1f-46b2-af2c-4b998ac4785b'
+      Finance::ExpenseCategories::COCA_COLA => COCA_COLA_ID,
+      Finance::ExpenseCategories::EATING_OUT => EATING_OUT_ID,
+      Finance::ExpenseCategories::FUN => FUN_ID,
+      Finance::ExpenseCategories::SUPERMARKET => SUPERMARKET_ID
     }.freeze
   end
 end

--- a/config/initializers/airtable.rb
+++ b/config/initializers/airtable.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Airrecord.api_key = ENV['AIRTABLE_TOKEN']

--- a/spec/jobs/finance/create_expense_job_spec.rb
+++ b/spec/jobs/finance/create_expense_job_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Finance::CreateExpenseJob do
 
       allow(YNAB::API).to receive(:new).and_return(mock_ynab)
       allow(mock_ynab).to receive_message_chain(:transactions, :create_transaction)
+
+      allow_any_instance_of(Airtable::Expense).to receive(:save)
     end
 
     it 'creates a new expense' do
@@ -40,6 +42,12 @@ RSpec.describe Finance::CreateExpenseJob do
 
     it 'publishes the expense in YNAB' do
       expect(mock_ynab).to receive_message_chain(:transactions, :create_transaction)
+
+      subject
+    end
+
+    it 'publishes the expense in Airtable' do
+      expect_any_instance_of(Airtable::Expense).to receive(:save)
 
       subject
     end

--- a/spec/services/airtable/expense_spec.rb
+++ b/spec/services/airtable/expense_spec.rb
@@ -3,6 +3,10 @@
 RSpec.describe Airtable::Expense do
   let(:finance_expense) { Finance::Expense.new(amount: 42.24, notes: 'Expense for testing', category: 'eating out') }
 
+  before do
+    allow_any_instance_of(described_class).to receive(:save)
+  end
+
   describe '.from_expense' do
     subject(:expense) { Airtable::Expense.from_expense(finance_expense) }
 

--- a/spec/services/airtable/expense_spec.rb
+++ b/spec/services/airtable/expense_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Airtable::Expense do
+  let(:finance_expense) { Finance::Expense.new(amount: 42.24, notes: 'Expense for testing', category: 'eating out') }
+
+  describe '.from_expense' do
+    subject(:expense) { Airtable::Expense.from_expense(finance_expense) }
+
+    before { finance_expense.save }
+
+    it('sets the title') { expect(expense.title).to eq 'Expense for testing' }
+    it('sets the amount') { expect(expense.amount).to eq 42.24 }
+    it('sets the category') { expect(expense.category).to eq 'Bar / Restaurant' }
+    it('sets the datetime') { expect(expense.datetime).to eq finance_expense.created_at.strftime('%Y-%m-%dT%H:%M:%S%Z') }
+  end
+end


### PR DESCRIPTION
### What?
Integrating with the Airtable base in which I keep track of my expenses. With these changes the expenses will be published there automatically, similarly to what happens now with YNAB and CloudWatch

### How?
In order to interact with Airtable, we use [sirupsen/airrecord](https://github.com/sirupsen/airrecord). It allows us to interact with Tables using a ORM-like interface, very similar to the one used by ActiveRecord

We'll represent the Expenses using the `Airtable::Expense` class. We have added a factory class method, `.from_expense`, that automatically extracts the information from a `Finance::Expense` class an saves it in Airtable.