### PR TITLE
Metric classes

### DIFF
--- a/app/models/metrics/base_metric.rb
+++ b/app/models/metrics/base_metric.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Metrics::BaseMetric < Aws::CloudWatch::Types::MetricDatum
+  UNIT_COUNT = 'Count'
+
+  def ==(other)
+    other.class == self.class &&
+      other.metric_name == self.metric_name &&
+      other.value == self.value &&
+      other.timestamp == self.timestamp &&
+      compare_dimensions(other)
+  end
+
+  def contains_dimension?(other_dimension)
+    dimensions.any? { |dimension| dimension == other_dimension }
+  end
+
+  private
+
+  def compare_dimensions(other)
+    return false unless dimensions.size == other.dimensions.size
+
+    other.dimensions.all? { |dimension| contains_dimension?(dimension) }
+  end
+end

--- a/app/models/metrics/expense_metric.rb
+++ b/app/models/metrics/expense_metric.rb
@@ -4,11 +4,27 @@ module Metrics
   class ExpenseMetric < BaseMetric
     METRIC_NAME = 'Money spent'
 
+    DIMENSION_COCA_COLA = 'Coca cola'
+    DIMENSION_EATING_OUT = 'Eating out'
+    DIMENSION_FUN = 'Fun'
+    DIMENSION_SUPERMARKET = 'Supermarket'
+
     def initialize(expense)
       self.metric_name = METRIC_NAME
-      self.dimensions = [{ name: 'Category', value: expense.category }]
+      self.dimensions = [{ name: 'Category', value: map_category(expense) }]
       self.timestamp = expense.created_at
       self.value = expense.amount.to_f
+    end
+
+    private
+
+    def map_category(expense)
+      {
+        Finance::ExpenseCategories::COCA_COLA => DIMENSION_COCA_COLA,
+        Finance::ExpenseCategories::EATING_OUT => DIMENSION_EATING_OUT,
+        Finance::ExpenseCategories::FUN => DIMENSION_FUN,
+        Finance::ExpenseCategories::SUPERMARKET => DIMENSION_SUPERMARKET
+      }[expense.category]
     end
   end
 end

--- a/app/models/metrics/expense_metric.rb
+++ b/app/models/metrics/expense_metric.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Metrics
+  class ExpenseMetric < BaseMetric
+    METRIC_NAME = 'Money spent'
+
+    def initialize(expense)
+      self.metric_name = METRIC_NAME
+      self.dimensions = [{ name: 'Category', value: expense.category }]
+      self.timestamp = expense.created_at
+      self.value = expense.amount.to_f
+    end
+  end
+end

--- a/app/models/metrics/injection_metric.rb
+++ b/app/models/metrics/injection_metric.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Metrics
+  class InjectionMetric < BaseMetric
+    METRIC_NAME = 'Insulin'
+
+    def initialize(injection)
+      self.metric_name = METRIC_NAME
+      self.dimensions = [{ name: 'Type', value: injection.injection_type }]
+      self.timestamp = injection.created_at
+      self.value = injection.units.to_f
+      self.unit = UNIT_COUNT
+    end
+  end
+end

--- a/app/models/metrics/injection_metric.rb
+++ b/app/models/metrics/injection_metric.rb
@@ -4,12 +4,24 @@ module Metrics
   class InjectionMetric < BaseMetric
     METRIC_NAME = 'Insulin'
 
+    DIMENSION_BASAL = 'Basal'
+    DIMENSION_BOLUS = 'Bolus'
+
     def initialize(injection)
       self.metric_name = METRIC_NAME
-      self.dimensions = [{ name: 'Type', value: injection.injection_type }]
+      self.dimensions = [{ name: 'Type', value: map_injection_type(injection) }]
       self.timestamp = injection.created_at
       self.value = injection.units.to_f
       self.unit = UNIT_COUNT
+    end
+
+    private
+
+    def map_injection_type(injection)
+      {
+        'basal' => DIMENSION_BASAL,
+        'bolus' => DIMENSION_BOLUS
+      }[injection.injection_type]
     end
   end
 end

--- a/app/services/aws_services/cloudwatch_wrapper.rb
+++ b/app/services/aws_services/cloudwatch_wrapper.rb
@@ -9,19 +9,8 @@ module AwsServices
     end
 
     def publish_injection(injection)
-      client.put_metric_data(
-        namespace: 'Health',
-        metric_data: [{
-          metric_name: 'Insulin',
-          dimensions: [{
-            name: 'Type',
-            value: injection.injection_type
-          }],
-          timestamp: injection.created_at,
-          value: injection.units.to_f,
-          unit: 'Count'
-        }]
-      )
+      metric_data = Metrics::InjectionMetric.new(injection)
+      client.put_metric_data(namespace: 'Health', metric_data: [metric_data])
     end
 
     def publish_expense(expense)

--- a/app/services/aws_services/cloudwatch_wrapper.rb
+++ b/app/services/aws_services/cloudwatch_wrapper.rb
@@ -25,18 +25,8 @@ module AwsServices
     end
 
     def publish_expense(expense)
-      client.put_metric_data(
-        namespace: 'Finance',
-        metric_data: [{
-          metric_name: 'Money spent',
-          timestamp: expense.created_at,
-          dimensions: [{
-            name: 'Category',
-            value: expense.category
-          }],
-          value: expense.amount.to_f
-        }]
-      )
+      metric_data = Metrics::ExpenseMetric.new(expense)
+      client.put_metric_data(namespace: 'Finance', metric_data: [metric_data])
     end
   end
 end

--- a/spec/models/metrics/base_metric_spec.rb
+++ b/spec/models/metrics/base_metric_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe Metrics::BaseMetric do
+  let(:metric) do
+    described_class.new(
+      metric_name: 'test', value: 1, timestamp: Time.now,
+      dimensions: [{ name: 'Dim1', value: 'Val1' }, { name: 'Dim2', value: 'Val2' }]
+    )
+  end
+
+  describe '#==' do
+    let(:metric2) { metric.dup }
+
+    it 'compares the metric name' do
+      expect(metric2).to eq metric
+
+      metric2.metric_name = 'other'
+      expect(metric2).not_to eq metric
+    end
+
+    it 'compares the metric value' do
+      expect(metric2).to eq metric
+
+      metric2.value = 'other'
+      expect(metric2).not_to eq metric
+    end
+
+    it 'compares the metric timestamp' do
+      expect(metric2).to eq metric
+
+      metric2.timestamp = Time.now + 1.minute
+      expect(metric2).not_to eq metric
+    end
+
+    context 'compares dimensions' do
+
+      before { metric2.dimensions = metric.dimensions.map(&:clone) }
+
+      it 'returns true if their names and values match' do
+        expect(metric2).to eq(metric)
+      end
+
+      it 'returns false if there are extra dimensions' do
+        metric2.dimensions << { name: 'Dim3', value: 'Val3' }
+
+        expect(metric2).not_to eq metric
+      end
+
+      it 'returns false if the dimension names do not match' do
+        metric2.dimensions.first[:name] = 'OtherDim'
+
+        expect(metric2).not_to eq metric
+      end
+
+      it 'returns false if the dimension values do not match' do
+        metric2.dimensions.first[:value] = 'OtherValue'
+
+        expect(metric2).not_to eq metric
+      end
+    end
+  end
+
+  describe '#contains_dimension?' do
+    it 'returns true if the dimension name and value match' do
+      dimension = { name: 'Dim2', value: 'Val2' }
+
+      expect(metric.contains_dimension?(dimension)).to be_truthy
+    end
+
+    it 'returns false if there are no dimensions with that name' do
+      dimension = { name: 'FakeDim', value: 'Value' }
+
+      expect(metric.contains_dimension?(dimension)).to be_falsey
+    end
+
+    it 'returns false if the dimension value does not match' do
+      dimension = { name: 'Dim2', value: 'FakeValue' }
+
+      expect(metric.contains_dimension?(dimension)).to be_falsey
+    end
+  end
+end

--- a/spec/models/metrics/expense_metric_spec.rb
+++ b/spec/models/metrics/expense_metric_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Metrics::ExpenseMetric do
+  let(:expense) do
+    Finance::Expense.new(
+      amount: 12,
+      category: Finance::ExpenseCategories::SUPERMARKET,
+      notes: 'test injection'
+    )
+  end
+
+  describe '#new' do
+    subject(:metric) { Metrics::ExpenseMetric.new(expense) }
+
+    it 'sets the metric name' do
+      expect(metric.metric_name).to eq 'Money spent'
+    end
+
+    it 'sets the metric value' do
+      expect(metric.value).to eq 12
+    end
+
+    it 'sets the timestamp' do
+      expect(metric.timestamp).to eq expense.created_at
+    end
+
+    it 'sets only one dimension' do
+      expect(metric.dimensions.size).to eq 1
+    end
+
+    it 'sets the "Category" dimension' do
+      dimension = metric.dimensions.first
+      expect(dimension[:name]).to eq 'Category'
+      expect(dimension[:value]).to eq 'Supermarket'
+    end
+  end
+end

--- a/spec/models/metrics/injection_metric_spec.rb
+++ b/spec/models/metrics/injection_metric_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Metrics::InjectionMetric do
     it 'sets the "Type" dimension' do
       dimension = metric.dimensions.first
       expect(dimension[:name]).to eq 'Type'
-      expect(dimension[:value]).to eq 'basal'
+      expect(dimension[:value]).to eq 'Basal'
     end
   end
 end

--- a/spec/models/metrics/injection_metric_spec.rb
+++ b/spec/models/metrics/injection_metric_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Metrics::InjectionMetric do
+  let(:injection) { Health::Injection.new(units: 22, injection_type: 'basal', notes: 'test injection') }
+
+  describe '#new' do
+    subject(:metric) { Metrics::InjectionMetric.new(injection) }
+
+    it 'sets the metric name' do
+      expect(metric.metric_name).to eq 'Insulin'
+    end
+
+    it 'sets the metric value' do
+      expect(metric.value).to eq 22
+    end
+
+    it 'sets the units' do
+      expect(metric.unit).to eq 'Count'
+    end
+
+    it 'sets the timestamp' do
+      expect(metric.timestamp).to eq injection.created_at
+    end
+
+    it 'sets only one dimension' do
+      expect(metric.dimensions.size).to eq 1
+    end
+
+    it 'sets the "Type" dimension' do
+      dimension = metric.dimensions.first
+      expect(dimension[:name]).to eq 'Type'
+      expect(dimension[:value]).to eq 'basal'
+    end
+  end
+end

--- a/spec/services/aws_services/cloudwatch_wrapper_spec.rb
+++ b/spec/services/aws_services/cloudwatch_wrapper_spec.rb
@@ -8,9 +8,20 @@ RSpec.describe AwsServices::CloudwatchWrapper do
     allow(metrics_service).to receive(:put_metric_data)
   end
 
-  describe '#publish_expense' do
-    before { allow(metrics_service).to receive(:put_metric_data) }
+  describe '#publish_injection' do
+    it 'publishes the injection in CloudWatch' do
+      injection = Health::Injection.new(units: 22, injection_type: 'basal', notes: 'test injection')
+      expected_metric_data = {
+        namespace: 'Health',
+        metric_data: [Metrics::InjectionMetric.new(injection)]
+      }
 
+      expect(metrics_service).to receive(:put_metric_data).with(expected_metric_data)
+      AwsServices::CloudwatchWrapper.new.publish_injection(injection)
+    end
+  end
+
+  describe '#publish_expense' do
     it 'publishes the expense in CloudWatch' do
       expense = Finance::Expense.new(amount: 42, category: 'eating out', notes: 'test expense note')
       expected_metric_data = {

--- a/spec/services/aws_services/cloudwatch_wrapper_spec.rb
+++ b/spec/services/aws_services/cloudwatch_wrapper_spec.rb
@@ -3,7 +3,10 @@
 RSpec.describe AwsServices::CloudwatchWrapper do
   let(:metrics_service) { instance_double(Aws::CloudWatch::Client) }
 
-  before { allow(Aws::CloudWatch::Client).to receive(:new).and_return metrics_service }
+  before do
+    allow(Aws::CloudWatch::Client).to receive(:new).and_return metrics_service
+    allow(metrics_service).to receive(:put_metric_data)
+  end
 
   describe '#publish_expense' do
     before { allow(metrics_service).to receive(:put_metric_data) }
@@ -12,15 +15,7 @@ RSpec.describe AwsServices::CloudwatchWrapper do
       expense = Finance::Expense.new(amount: 42, category: 'eating out', notes: 'test expense note')
       expected_metric_data = {
         namespace: 'Finance',
-        metric_data: [{
-          metric_name: 'Money spent',
-          timestamp: expense.created_at,
-          dimensions: [{
-            name: 'Category',
-            value: 'eating out'
-          }],
-          value: 42.0
-        }]
+        metric_data: [Metrics::ExpenseMetric.new(expense)]
       }
 
       expect(metrics_service).to receive(:put_metric_data).with(expected_metric_data)


### PR DESCRIPTION
### Description
This changes use an OOP approach to publish metrics. Instead of what we were doing previously (converting the object to a hash and publishing it directly) now we have classes that represent each Metric that we want to public. 

The main advantages of this approach are:

1) Having a cleaner and more readable interface for metrics publication
2) Simplifying the testability of the code that publishes metrics (we can test separately if the object is being published, if it's being created correctly, etc)

Additionally, in each of the Metric classes we have created hashes to map from the values in the Injection/Expense to the Dimensions of the metric. This encapsulate this logic in a single place instead of spreading it through the code. We have also used the change **to rename the metric dimensions** to make them more readable. While this will be beneficial in the long term, it will also mean that our current dashboards won't work until we manually change them