### PR TITLE
Category improvements

### DIFF
--- a/app/jobs/publish_empty_datapoints_job.rb
+++ b/app/jobs/publish_empty_datapoints_job.rb
@@ -6,11 +6,10 @@ class PublishEmptyDatapointsJob < ApplicationJob
   def publish
     cloudwatch = AwsServices::CloudwatchWrapper.new
 
-    empty_basal = Health::Injection.new(injection_type: 'basal', units: 0)
-    cloudwatch.publish_injection(empty_basal)
-
-    empty_bolus = Health::Injection.new(injection_type: 'bolus', units: 0)
-    cloudwatch.publish_injection(empty_bolus)
+    Health::Injection::TYPES.each do |injection_type|
+      empty_injection = Health::Injection.new(injection_type: injection_type, units: 0)
+      cloudwatch.publish_injection(empty_injection)
+    end
 
     Finance::ExpenseCategories::ALL.each do |category|
       empty_expense = Finance::Expense.new(amount: 0, category: category)

--- a/app/models/finance/expense.rb
+++ b/app/models/finance/expense.rb
@@ -10,12 +10,23 @@ module Finance
 
     validates_presence_of :amount
     validates_presence_of :category
+    validate :category_is_a_valid_expense_category
+
+    def category=(value)
+      self[:category] = value.downcase
+    end
 
     def ==(other)
       other.class == self.class &&
         other.amount == self.amount &&
         other.category == self.category &&
         other.notes == self.notes
+    end
+
+    private
+
+    def category_is_a_valid_expense_category
+      errors.add(:category, 'Invalid category') unless Finance::ExpenseCategories::ALL.include? category
     end
   end
 end

--- a/app/models/health/injection.rb
+++ b/app/models/health/injection.rb
@@ -4,18 +4,33 @@ module Health
   class Injection
     include Dynamoid::Document
 
+    TYPE_BASAL = 'basal'
+    TYPE_BOLUS = 'bolus'
+    TYPES = [TYPE_BASAL, TYPE_BOLUS]
+
     field :injection_type, :string
     field :notes, :string
     field :units, :number
 
     validates_presence_of :injection_type
     validates_presence_of :units
+    validate :validate_injection_type
+
+    def injection_type=(value)
+      self[:injection_type] = value.downcase
+    end
 
     def ==(other)
       other.class == self.class &&
         other.units == self.units &&
         other.injection_type == self.injection_type &&
         other.notes == self.notes
+    end
+
+    private
+
+    def validate_injection_type
+      errors.add(:injection_type, 'Invalid injection type') unless TYPES.include? injection_type
     end
   end
 end

--- a/app/models/metrics/injection_metric.rb
+++ b/app/models/metrics/injection_metric.rb
@@ -19,8 +19,8 @@ module Metrics
 
     def map_injection_type(injection)
       {
-        'basal' => DIMENSION_BASAL,
-        'bolus' => DIMENSION_BOLUS
+        Health::Injection::TYPE_BASAL => DIMENSION_BASAL,
+        Health::Injection::TYPE_BOLUS => DIMENSION_BOLUS
       }[injection.injection_type]
     end
   end

--- a/spec/fixtures/sns_events/finance/MoneySpent-invalid_category.json
+++ b/spec/fixtures/sns_events/finance/MoneySpent-invalid_category.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-1:598877714121:MoneySpent:bb252d77-c541-46c0-8a9e-5ba5aa45ee35",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "9d044cb2-0d73-5525-a38e-19048502e12c",
+        "TopicArn": "arn:aws:sns:eu-west-1:598877714121:MoneySpent",
+        "Subject": null,
+        "Message": "{\"amount\": 42.24, \"category\": \"Category that does not exist\", \"notes\": \"Expense testing notes\"}",
+        "Timestamp": "2019-07-27T17:13:21.905Z",
+        "SignatureVersion": "1",
+        "Signature": "DHe9GXILX41drnka/cgWVHFgO/+1Y39n0ERJzfSB/NoHE4K53DpdOrFC1tZUX/polhjgVL8XEZMoWC/p5mxv5di6vbqRqpyErldvKU3Maz6X06MKNoPlHUgeTRIruUa4Nd0tT049x5Chbym1AiK1a+/XTII0+UNk4SfEKuvMW4rlH3saRezWXKgUHhV3LuxhcAVpjQ0jdpvHxZqPTBCMe4dfY5RWCdHxHF83aAOEGJvjuoOoTmqnc1XGIJXTzQEBukBsD5ePIyTrWeZzVV+JJL7VpvEr26syasa7bgz6/qTa4AKjuu5GEZ2zR1J90C8DQJ1Ev1BJxZIFywWq0OsuSQ==",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe\\u0026SubscriptionArn=arn:aws:sns:eu-west-1:598877714121:MoneySpent:bb252d77-c541-46c0-8a9e-5ba5aa45ee35",
+        "MessageAttributes": {}
+      }
+    }
+  ]
+}

--- a/spec/fixtures/sns_events/finance/MoneySpent-uppercase.json
+++ b/spec/fixtures/sns_events/finance/MoneySpent-uppercase.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-1:598877714121:MoneySpent:bb252d77-c541-46c0-8a9e-5ba5aa45ee35",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "9d044cb2-0d73-5525-a38e-19048502e12c",
+        "TopicArn": "arn:aws:sns:eu-west-1:598877714121:MoneySpent",
+        "Subject": null,
+        "Message": "{\"amount\": 42.24, \"category\": \"EATING OUT\", \"notes\": \"Expense testing notes\"}",
+        "Timestamp": "2019-07-27T17:13:21.905Z",
+        "SignatureVersion": "1",
+        "Signature": "DHe9GXILX41drnka/cgWVHFgO/+1Y39n0ERJzfSB/NoHE4K53DpdOrFC1tZUX/polhjgVL8XEZMoWC/p5mxv5di6vbqRqpyErldvKU3Maz6X06MKNoPlHUgeTRIruUa4Nd0tT049x5Chbym1AiK1a+/XTII0+UNk4SfEKuvMW4rlH3saRezWXKgUHhV3LuxhcAVpjQ0jdpvHxZqPTBCMe4dfY5RWCdHxHF83aAOEGJvjuoOoTmqnc1XGIJXTzQEBukBsD5ePIyTrWeZzVV+JJL7VpvEr26syasa7bgz6/qTa4AKjuu5GEZ2zR1J90C8DQJ1Ev1BJxZIFywWq0OsuSQ==",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe\\u0026SubscriptionArn=arn:aws:sns:eu-west-1:598877714121:MoneySpent:bb252d77-c541-46c0-8a9e-5ba5aa45ee35",
+        "MessageAttributes": {}
+      }
+    }
+  ]
+}

--- a/spec/jobs/finance/create_expense_job_spec.rb
+++ b/spec/jobs/finance/create_expense_job_spec.rb
@@ -51,5 +51,25 @@ RSpec.describe Finance::CreateExpenseJob do
 
       subject
     end
+
+    context 'when the category is not in lowercase' do
+      let(:event) { JSON.parse(File.read('spec/fixtures/sns_events/finance/MoneySpent-uppercase.json')) }
+
+      it 'creates a new expense' do
+        expect { subject }.to change { Finance::Expense.all.count }.by 1
+      end
+
+      it 'sets the category in lowercase' do
+        expect(subject[:category]).to eq 'eating out'
+      end
+    end
+
+    context 'when the category is invalid' do
+      let(:event) { JSON.parse(File.read('spec/fixtures/sns_events/finance/MoneySpent-invalid_category.json')) }
+
+      it 'raises a validation error' do
+        expect { subject }.to raise_error Dynamoid::Errors::DocumentNotValid
+      end
+    end
   end
 end

--- a/spec/jobs/publish_empty_datapoints_job_spec.rb
+++ b/spec/jobs/publish_empty_datapoints_job_spec.rb
@@ -31,9 +31,7 @@ RSpec.describe PublishEmptyDatapointsJob do
     subject { described_class.perform_now(:publish) }
 
     context 'injections' do
-      INJECTION_TYPES = ['basal', 'bolus']
-
-      INJECTION_TYPES.each do |injection_type|
+      Health::Injection::TYPES.each do |injection_type|
         include_examples 'empty injection metrics', injection_type
       end
     end

--- a/spec/models/metrics/injection_metric_spec.rb
+++ b/spec/models/metrics/injection_metric_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Metrics::InjectionMetric do
-  let(:injection) { Health::Injection.new(units: 22, injection_type: 'basal', notes: 'test injection') }
+  let(:injection) { Health::Injection.new(units: 22, injection_type: Health::Injection::TYPE_BASAL, notes: 'test injection') }
 
   describe '#new' do
     subject(:metric) { Metrics::InjectionMetric.new(injection) }

--- a/spec/parsers/health/injection_parser_spec.rb
+++ b/spec/parsers/health/injection_parser_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Health::InjectionParser do
     subject { parser.parse }
 
     it 'returns a hash with the injection information' do
-      expected_injection = { units: 15, notes: 'Injection testing notes', injection_type: 'basal' }
+      expected_injection = { units: 15, notes: 'Injection testing notes', injection_type: Health::Injection::TYPE_BASAL }
 
       expect(subject).to include expected_injection
     end

--- a/spec/services/aws_services/cloudwatch_wrapper_spec.rb
+++ b/spec/services/aws_services/cloudwatch_wrapper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AwsServices::CloudwatchWrapper do
 
   describe '#publish_injection' do
     it 'publishes the injection in CloudWatch' do
-      injection = Health::Injection.new(units: 22, injection_type: 'basal', notes: 'test injection')
+      injection = Health::Injection.new(units: 22, injection_type: Health::Injection::TYPE_BASAL, notes: 'test injection')
       expected_metric_data = {
         namespace: 'Health',
         metric_data: [Metrics::InjectionMetric.new(injection)]

--- a/spec/services/ynab/transaction_data_spec.rb
+++ b/spec/services/ynab/transaction_data_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Ynab::TransactionData do
     it('sets the category id') { expect(transaction.category_id).to eq eating_out_category_id }
     it('marks the transaction as approved') { expect(transaction.approved).to be true }
 
-    context 'when the category is invalid' do
-      let(:expense) { Finance::Expense.new(amount: 42.0, notes: 'Expense for testing', category: 'Something random') }
+    context 'when the category is not mapped' do
+      let(:expense) { Finance::Expense.new(amount: 42.0, notes: 'Expense for testing', category: 'Something random', created_at: Time.now) }
       let(:uncategorized_category_id) { 'e172c064-eb5c-4fb2-9bd7-ae5fe9af692f' }
 
       it 'sets the transaction as "Uncategorized"' do


### PR DESCRIPTION
### Description
This PR includes general improvements related with how categories/types are handled in the application. More specifically

#### Expense
Two related changes here:

1) **Validating categories**: as there is a limited amount of valid
expense categories, we have added a validation to the `Finance::Expense`
model to be sure that only valid expenses are registered. If an invalid
category is set, trying to save the expense will raise a
`Dynamoid::Errors::DocumentNotValid` error

2) **Converting the category to lowercase**: In order to avoid getting
validation errors only because the user entered the category in a case
that isn't the default one (e.g. "Supermercado" instead of
"supermercado"), we have overriden the default setter to convert
the value to lowercase before assigning it

Both features have its corresponding tests added in
`CreateExpenseJob` specs. We have also made a minor modification in YNAB
TransactionData spec, as it does not makes sense now to have a category
that does not exist (it will raise an error before we get there).
Instead, we'll consider it as not mapped to a YNAB category


#### Injection
Doing with Injection.injection_type a similar process than the one used
in Expense.category: using constants defined in a single place to refer
to its values, and validating when creating an injection that the type
is correct