### PR TITLE
Send updates to Telegram

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ gem "httparty"
 gem 'aws-sdk-cloudwatch'
 gem 'ynab'
 gem 'airrecord'
-
-
+gem 'telegram-bot-ruby'
 
 group :development do
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,15 +87,23 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     builder (3.2.3)
     byebug (11.0.1)
     cfnresponse (0.4.0)
     climate_control (0.2.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     dotenv (2.7.5)
     dynamoid (3.2.0)
@@ -103,6 +111,7 @@ GEM
       aws-sdk-dynamodb (~> 1)
       concurrent-ruby (>= 1.0)
       null-logger
+    equalizer (0.0.11)
     erubi (1.8.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
@@ -120,6 +129,8 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    inflecto (0.0.2)
     jaro_winkler (1.5.3)
     jets (1.9.30)
       actionmailer (~> 5.2.1)
@@ -233,6 +244,10 @@ GEM
     safe_yaml (1.0.5)
     shotgun (0.9.2)
       rack (>= 1.0)
+    telegram-bot-ruby (0.12.0)
+      faraday
+      inflecto
+      virtus
     text-table (1.2.4)
     thor (0.20.3)
     thread_safe (0.3.6)
@@ -241,6 +256,11 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     webmock (3.7.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -267,6 +287,7 @@ DEPENDENCIES
   rspec
   rubocop
   shotgun
+  telegram-bot-ruby
   webmock
   ynab
 

--- a/app/services/telegram_bot.rb
+++ b/app/services/telegram_bot.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'telegram/bot'
+
+class TelegramBot
+  MARKDOWN_MODE = 'MarkdownV2'
+
+  def initialize
+    self.bot = Telegram::Bot::Client.run(bot_token) { |bot| bot }
+  end
+
+  def send_message(message)
+    bot.api.send_message(chat_id: chat_id, text: message, parse_mode: MARKDOWN_MODE)
+  end
+
+  private
+
+  attr_accessor :bot
+
+  def bot_id
+    ENV['TELEGRAM_BOT_ID']
+  end
+
+  def bot_token
+    ENV['TELEGRAM_BOT_TOKEN']
+  end
+
+  def chat_id
+    ENV['TELEGRAM_CHAT_ID']
+  end
+end

--- a/spec/fixtures/telegram_message.json
+++ b/spec/fixtures/telegram_message.json
@@ -1,0 +1,21 @@
+{
+    "ok": true,
+    "result": {
+        "message_id": 4382,
+        "from": {
+            "id": 603317491,
+            "is_bot": true,
+            "first_name": "BOT_NAME",
+            "username": "BOT_USERNAME"
+        },
+        "chat": {
+            "id": 12345,
+            "first_name": "RECEIVER_NAME",
+            "last_name": "RECEIVER_LAST_NAME",
+            "username": "RECEIVER_USER_NAME",
+            "type": "private"
+        },
+        "date": 1581250622,
+        "text": "Hey, this is a message!"
+    }
+}

--- a/spec/services/telegram_bot_spec.rb
+++ b/spec/services/telegram_bot_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe TelegramBot do
+  before do
+    allow(Telegram::Bot::Client)
+      .to receive(:run)
+      .and_return(instance_double(Telegram::Bot::Client))
+  end
+
+  around do |example|
+    with_modified_env(TELEGRAM_CHAT_ID: '123456') { example.run }
+  end
+
+  subject { described_class.new }
+
+  describe '#send_message' do
+    let(:message) { 'Hey, this is a message!' }
+    let(:sent_message_object) { load_json_fixture('telegram_message.json') }
+
+    before do
+      allow(subject).to receive_message_chain(:bot, :api, :send_message) { sent_message_object }
+    end
+
+    it 'sends the message' do
+      expect(subject)
+        .to receive_message_chain(:bot, :api, :send_message)
+        .with(chat_id: '123456', parse_mode: 'MarkdownV2', text: message)
+
+      subject.send_message message
+    end
+
+    it 'returns the message object' do
+      expect(subject.send_message('something')).to eq sent_message_object
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,3 +29,7 @@ end
 def with_modified_env(options, &block)
   ClimateControl.modify(options, &block)
 end
+
+def load_json_fixture(path)
+  JSON.parse(File.read("spec/fixtures/#{path}"))
+end


### PR DESCRIPTION
### Description
Adding a class to send messages to a specific Telegram chat. 

The functionality is quite simple: we implemented a method to send a message to the chat specified in the TELEGRAM_CHAT_ID env var. We have set the `bot` field as private in order to allow accessing it only from the specific methods, hiding undesired side-effects