### PR TITLE
Monitoring metrics publication with CloudWatch Alarms

### DIFF
--- a/app/commands/send_telegram_message_command.rb
+++ b/app/commands/send_telegram_message_command.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class SendTelegramMessageCommand
+  attr_reader :message
+
+  def initialize(message)
+    @message = message
+  end
+
+  def execute
+    telegram_bot.send_message(message)
+  end
+
+  private
+
+  def telegram_bot
+    @telegram_bot ||= TelegramBot.new
+  end
+end

--- a/app/helpers/emojis.rb
+++ b/app/helpers/emojis.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Emojis
+  BELL = "\xF0\x9F\x94\x94"
+end

--- a/app/jobs/alarm_received_job.rb
+++ b/app/jobs/alarm_received_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AlarmReceivedJob < ApplicationJob
+  def run
+    SendTelegramMessageCommand.new(telegram_message).execute
+  end
+
+  private
+
+  def alarm
+    @alarm ||= AlarmParser.new(event).parse
+  end
+
+  def telegram_message
+    <<~MSG
+    #{Emojis::BELL} Alarm! Alarm! #{Emojis::BELL}
+
+    The alarm "#{alarm.name}" has entered into "#{alarm.state}"
+
+    Reason:
+    #{alarm.reason}
+    MSG
+  end
+end

--- a/app/jobs/alarm_received_job.rb
+++ b/app/jobs/alarm_received_job.rb
@@ -14,9 +14,9 @@ class AlarmReceivedJob < ApplicationJob
 
   def telegram_message
     <<~MSG
-    #{Emojis::BELL} Alarm! Alarm! #{Emojis::BELL}
+    #{Emojis::BELL} *Alarm! Alarm!* #{Emojis::BELL}
 
-    The alarm "#{alarm.name}" has entered into "#{alarm.state}"
+    The alarm "#{alarm.name}" has changed to "#{alarm.state}"
 
     Reason:
     #{alarm.reason}

--- a/app/jobs/alarm_received_job.rb
+++ b/app/jobs/alarm_received_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AlarmReceivedJob < ApplicationJob
+  sns_event 'AlarmFired'
   def run
     SendTelegramMessageCommand.new(telegram_message).execute
   end

--- a/app/models/alarm.rb
+++ b/app/models/alarm.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Alarm
+  attr_accessor :description, :name, :reason, :state
+
+  STATE_ALARM = 'ALARM'
+  STATE_OK = 'OK'
+  STATE_INSUFFICIENT_DATA = 'INSUFFICIENT_DATA'
+  POSSIBLE_STATES = {
+    alarm: STATE_ALARM,
+    ok: STATE_OK,
+    insufficient_data: STATE_INSUFFICIENT_DATA
+  }
+
+  POSSIBLE_STATES.each do |name, value|
+    define_method "#{name}?" do
+      state == value
+    end
+
+    define_method "#{name}!" do
+      self.state = value
+    end
+  end
+end

--- a/app/parsers/alarm_parser.rb
+++ b/app/parsers/alarm_parser.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AlarmParser < SnsParser
+  def parse
+    alarm = Alarm.new
+
+    alarm.name = event['AlarmName']
+    alarm.description = event['AlarmDescription']
+    alarm.reason = event['NewStateReason']
+    alarm.state = event['NewStateValue']
+
+    alarm
+  end
+end

--- a/app/services/telegram_bot.rb
+++ b/app/services/telegram_bot.rb
@@ -4,7 +4,7 @@ require 'telegram/bot'
 
 class TelegramBot
   MARKDOWN_MODE = 'MarkdownV2'
-  RESERVED_CHARACTERS = '.$%-{}\/'
+  RESERVED_CHARACTERS = '.$%-{}\/!()'
 
   def initialize
     @bot = Telegram::Bot::Client.run(bot_token) { |bot| bot }

--- a/app/services/telegram_bot.rb
+++ b/app/services/telegram_bot.rb
@@ -4,7 +4,7 @@ require 'telegram/bot'
 
 class TelegramBot
   MARKDOWN_MODE = 'MarkdownV2'
-  RESERVED_CHARACTERS = '.$%-{}\/!()'
+  RESERVED_CHARACTERS = '.$%-{}\/!()_+#'
 
   def initialize
     @bot = Telegram::Bot::Client.run(bot_token) { |bot| bot }

--- a/infrastructure/alarms.yml
+++ b/infrastructure/alarms.yml
@@ -59,7 +59,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: Finance
-              MetricName: Expense
+              MetricName: Money spent
               Dimensions:
                 - Name: Category
                   Value: Coca cola
@@ -70,7 +70,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: Finance
-              MetricName: Expense
+              MetricName: Money spent
               Dimensions:
                 - Name: Category
                   Value: Eating out
@@ -81,7 +81,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: Finance
-              MetricName: Expense
+              MetricName: Money spent
               Dimensions:
                 - Name: Category
                   Value: Fun
@@ -92,7 +92,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: Finance
-              MetricName: Expense
+              MetricName: Money spent
               Dimensions:
                 - Name: Category
                   Value: Supermarket

--- a/infrastructure/alarms.yml
+++ b/infrastructure/alarms.yml
@@ -1,0 +1,99 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: CloudWatch Alarms used to verify that the components in alexgascon-api are working properly
+
+Resources:
+  BasalNotPublishedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alexgascon-api_Basal-Insulin-Not-Published
+      AlarmDescription: Alarm to monitor if basal insulin's datapoints are being published correctly
+      Namespace: Health
+      MetricName: Insulin
+      Dimensions:
+      - Name: Type
+        Value: Basal
+      Unit: Count
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 1
+      Period: 3600
+      Statistic: SampleCount
+      Threshold: 1
+      TreatMissingData: breaching
+
+  BolusNotPublishedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alexgascon-api_Bolus-Insulin-Not-Published
+      AlarmDescription: Alarm to monitor if bolus insulin's datapoints are being published correctly
+      Namespace: Health
+      MetricName: Insulin
+      Dimensions:
+        - Name: Type
+          Value: Bolus
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 1
+      Period: 3600
+      Statistic: SampleCount
+      Threshold: 1
+      TreatMissingData: breaching
+      Unit: Count
+
+  ExpensesNotPublishedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alexgascon-api_Expenses-Not-Published
+      AlarmDescription: Alarm to monitor if datapoints for the expense categories are being published correctly
+      Metrics:
+        - Label: Expense datapoints
+          Id: e1
+          Expression: SUM([m1, m2, m3, m4])
+          ReturnData: true
+        - Id: m1
+          MetricStat:
+            Metric:
+              Namespace: Finance
+              MetricName: Expense
+              Dimensions:
+                - Name: Category
+                  Value: Coca cola
+            Period: 3600
+            Stat: SampleCount
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Namespace: Finance
+              MetricName: Expense
+              Dimensions:
+                - Name: Category
+                  Value: Eating out
+            Period: 3600
+            Stat: SampleCount
+          ReturnData: false
+        - Id: m3
+          MetricStat:
+            Metric:
+              Namespace: Finance
+              MetricName: Expense
+              Dimensions:
+                - Name: Category
+                  Value: Fun
+            Period: 3600
+            Stat: SampleCount
+          ReturnData: false
+        - Id: m4
+          MetricStat:
+            Metric:
+              Namespace: Finance
+              MetricName: Expense
+              Dimensions:
+                - Name: Category
+                  Value: Supermarket
+            Period: 3600
+            Stat: SampleCount
+          ReturnData: false
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 1
+      Threshold: 4
+      TreatMissingData: breaching

--- a/infrastructure/alarms.yml
+++ b/infrastructure/alarms.yml
@@ -20,6 +20,9 @@ Resources:
       Statistic: SampleCount
       Threshold: 1
       TreatMissingData: breaching
+      AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      InsufficientDataActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
 
   BolusNotPublishedAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -38,6 +41,9 @@ Resources:
       Threshold: 1
       TreatMissingData: breaching
       Unit: Count
+      AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      InsufficientDataActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
 
   ExpensesNotPublishedAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -97,3 +103,6 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 4
       TreatMissingData: breaching
+      AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      InsufficientDataActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -3,3 +3,9 @@ bundle exec jets deploy production
 
 echo "Creating the new DynamoDB tables..."
 JETS_ENV=production bundle exec rake dynamoid:create_tables
+
+echo "Updating the CloudFormation stacks..."
+aws cloudformation deploy \
+	--template-file infrastructure/alarms.yml \
+	--stack-name alexgascon-api-Alarms \
+	--no-fail-on-empty-changeset

--- a/spec/commands/send_telegram_message_command_spec.rb
+++ b/spec/commands/send_telegram_message_command_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe SendTelegramMessageCommand do
+  describe 'execute' do
+    before { allow_any_instance_of(TelegramBot).to receive(:send_message) }
+
+    it 'sends a telegram message' do
+      message = 'Hey, this is a Telegram message'
+      command = described_class.new(message)
+
+      expect_any_instance_of(TelegramBot).to receive(:send_message).with(message)
+
+      command.execute
+    end
+  end
+end

--- a/spec/fixtures/sns_events/cloudwatch_alarm.json
+++ b/spec/fixtures/sns_events/cloudwatch_alarm.json
@@ -1,0 +1,20 @@
+{
+    "Records": [{
+        "EventSource": "aws:sns",
+        "EventVersion": "1.0",
+        "EventSubscriptionArn": "arn:aws:sns:eu-west-1:000000000000:cloudwatch-alarms:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "Sns": {
+            "Type": "Notification",
+            "MessageId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "TopicArn": "arn:aws:sns:eu-west-1:000000000000:cloudwatch-alarms",
+            "Subject": "ALARM: \"Example alarm name\" in EU - Ireland",
+            "Message": "{\"AlarmName\":\"Example alarm name\",\"AlarmDescription\":\"Example alarm description.\",\"AWSAccountId\":\"000000000000\",\"NewStateValue\":\"ALARM\",\"NewStateReason\":\"Threshold Crossed: 1 datapoint (10.0) was greater than or equal to the threshold (1.0).\",\"StateChangeTime\":\"2017-01-12T16:30:42.236+0000\",\"Region\":\"EU - Ireland\",\"OldStateValue\":\"OK\",\"Trigger\":{\"MetricName\":\"DeliveryErrors\",\"Namespace\":\"ExampleNamespace\",\"Statistic\":\"SUM\",\"Unit\":null,\"Dimensions\":[],\"Period\":300,\"EvaluationPeriods\":1,\"ComparisonOperator\":\"GreaterThanOrEqualToThreshold\",\"Threshold\":1.0}}",
+            "Timestamp": "2017-01-12T16:30:42.318Z",
+            "SignatureVersion": "1",
+            "Signature": "Cg==",
+            "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.pem",
+            "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:000000000000:cloudwatch-alarms:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "MessageAttributes": {}
+        }
+    }]
+}

--- a/spec/fixtures/telegram/telegram_message.json
+++ b/spec/fixtures/telegram/telegram_message.json
@@ -16,6 +16,6 @@
             "type": "private"
         },
         "date": 1581250622,
-        "text": "Hey, this is a message!"
+        "text": "Hey, this is a message"
     }
 }

--- a/spec/jobs/alarm_received_job_spec.rb
+++ b/spec/jobs/alarm_received_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe AlarmReceivedJob do
+  subject { described_class.perform_now(:run, event) }
+
+  describe 'run' do
+    before do
+      allow(SendTelegramMessageCommand).to receive(:new).and_call_original
+      allow_any_instance_of(SendTelegramMessageCommand).to receive :execute
+    end
+
+    let(:event) { load_json_fixture('sns_events/cloudwatch_alarm') }
+
+    it 'sends a Telegram message' do
+      expect_any_instance_of(SendTelegramMessageCommand).to receive(:execute)
+
+      subject
+    end
+
+    it 'passes the correct message to the command' do
+      expected_message = <<~MSG
+      \xF0\x9F\x94\x94 Alarm! Alarm! \xF0\x9F\x94\x94
+
+      The alarm "Example alarm name" has entered into "ALARM"
+
+      Reason:
+      Threshold Crossed: 1 datapoint (10.0) was greater than or equal to the threshold (1.0).
+      MSG
+
+      expect(SendTelegramMessageCommand).to receive(:new).with(expected_message)
+
+      subject
+    end
+  end
+end

--- a/spec/jobs/alarm_received_job_spec.rb
+++ b/spec/jobs/alarm_received_job_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe AlarmReceivedJob do
 
     it 'passes the correct message to the command' do
       expected_message = <<~MSG
-      \xF0\x9F\x94\x94 Alarm! Alarm! \xF0\x9F\x94\x94
+      \xF0\x9F\x94\x94 *Alarm! Alarm!* \xF0\x9F\x94\x94
 
-      The alarm "Example alarm name" has entered into "ALARM"
+      The alarm "Example alarm name" has changed to "ALARM"
 
       Reason:
       Threshold Crossed: 1 datapoint (10.0) was greater than or equal to the threshold (1.0).

--- a/spec/models/alarm_spec.rb
+++ b/spec/models/alarm_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe Alarm do
+  subject { described_class.new }
+
+  describe 'state' do
+    states = {
+      alarm: 'ALARM',
+      ok: 'OK',
+      insufficient_data: 'INSUFFICIENT_DATA'
+    }
+
+    states.each do |state, value|
+      it "#{state}! sets the state to #{value}" do
+        method = "#{state}!".to_sym
+        subject.send(method)
+
+        expect(subject.state).to eq value
+      end
+
+      it "#{state}? verifies that the state is #{value}" do 
+        method = "#{state}?".to_sym
+        expect(subject.send(method)).to be false
+
+        subject.state = value
+
+        expect(subject.send(method)).to be true
+      end
+    end
+  end
+end

--- a/spec/parsers/alarm_parser_spec.rb
+++ b/spec/parsers/alarm_parser_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe AlarmParser do
+  describe 'parse' do
+    let(:event) { load_json_fixture('sns_events/cloudwatch_alarm') }
+    let(:parser) { described_class.new(event) }
+
+    subject(:alarm) { parser.parse }
+
+    it 'sets the alarm name' do
+      expect(alarm.name).to eq 'Example alarm name'
+    end
+
+    it 'sets the alarm description' do
+      expect(alarm.description).to eq 'Example alarm description.'
+    end
+
+    it 'sets the alarm state' do
+      expect(alarm.alarm?).to be true
+    end
+
+    it 'includes the reason for the last alarm transition' do
+      expected_reason = 'Threshold Crossed: 1 datapoint (10.0) was greater than or equal to the threshold (1.0).'
+      expect(alarm.reason).to eq expected_reason
+    end
+  end
+end

--- a/spec/services/telegram_bot_spec.rb
+++ b/spec/services/telegram_bot_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TelegramBot do
   subject { described_class.new }
 
   describe '#send_message' do
-    let(:message) { 'Hey, this is a message!' }
+    let(:message) { 'Hey, this is a message' }
     let(:sent_message_object) { load_json_fixture('telegram/telegram_message') }
 
     before do


### PR DESCRIPTION
### Description
In order to monitor the health of the services, we'll add a set of CloudWatch Alarms that will verify that metrics are being published. We'll have 3 different alarms: one to measure basal insulin, one to measure bolus insulin, and one to measure all the expense categories together. The alarm threshold has been set to 1 datapoint per hour, because that's the publication rate that we have by default (on the expenses alarm, the threshold is 4 because we're monitoring 4 metrics at the same time): everything under that will trigger the alarm.

When the alarm changes state, it will publish an event to a new SNS topic, `AlarmFired`, that will extract the information and notify us via Telegram. 