### PR TITLE
Notifying Openbank transactions

### DIFF
--- a/app/helpers/emojis.rb
+++ b/app/helpers/emojis.rb
@@ -2,4 +2,7 @@
 
 module Emojis
   BELL = "\xF0\x9F\x94\x94"
+  FLYING_MONEY = "\xF0\x9F\x92\xB8"
+  MONEY_BAG = "\xF0\x9F\x92\xB0"
+  RIGHT_ARROW = "\xE2\x9E\xA1"
 end

--- a/app/jobs/finance/notify_yesterday_transactions_job.rb
+++ b/app/jobs/finance/notify_yesterday_transactions_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Finance
+  class NotifyYesterdayTransactionsJob < ::ApplicationJob
+
+    cron '27 12 * * ? *'
+    def run
+      return if yesterday_transactions.empty?
+
+      SendTelegramMessageCommand.new(telegram_message).execute
+    end
+
+    private
+
+    def yesterday_transactions
+      @yesterday_transactions ||= Finance::BankTransaction.where('datetime.gte': Date.yesterday)
+    end
+
+    def telegram_message
+      <<~MSG
+      #{Emojis::FLYING_MONEY} #{yesterday_transactions.size} expenses yesterday #{Emojis::FLYING_MONEY}
+
+      #{yesterday_transactions.map { |t| format_transaction(t) }.join("\n\n")}
+
+      Total: #{yesterday_transactions.map(&:amount).sum}€
+      MSG
+    end
+
+    def format_transaction(transaction)
+      "#{Emojis::MONEY_BAG} #{transaction.amount}€: #{transaction.description}"
+    end
+  end
+end

--- a/app/jobs/finance/retrieve_yesterday_transactions_job.rb
+++ b/app/jobs/finance/retrieve_yesterday_transactions_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Finance
+  class RetrieveYesterdayTransactionsJob < ::ApplicationJob
+
+    cron '27 01 * * ? *'
+    def run
+      openbank = Finance::Openbank::Service.new
+      transactions_data = openbank.get_transactions(Date.yesterday)
+
+      return if transaction_data.empty?
+
+      transactions_data.each do |transaction_data|
+        Finance::Openbank::TransactionBuilder.new(transaction_data).build
+      end
+    end
+  end
+end

--- a/app/models/finance/bank_transaction.rb
+++ b/app/models/finance/bank_transaction.rb
@@ -23,6 +23,10 @@ module Finance
     validates_presence_of :description
     validate :bank_information_is_valid?
 
+    def amount
+      (amount_in_cents / 100).round(2)
+    end
+
     def expense?
       amount_in_cents.negative?
     end

--- a/app/services/finance/openbank/service.rb
+++ b/app/services/finance/openbank/service.rb
@@ -8,7 +8,9 @@ module Finance
 
       MAX_RETRIES = 3
 
-      def get_transactions(from, to = Date.today)
+      def get_transactions(from, to = nil)
+        to ||= from
+
         authenticate unless @auth_token
 
         response = request_transactions(from, to)


### PR DESCRIPTION
### Description
Adding a set of jobs to retrieve information about the recent bank
transactions on Openbank and sending their information via Telegram.

We have separated the logic into two different jobs:
- **RetrieveYesterdayTransactionsJob**: This job will connect with
Openbank and obtain the information about the bank transactions that
happened the previous day and will store them in the system.
- **NotifyYesterdayTransactionsJob**: This job will query yesterday's
`Finance::BankTransactions` from DynamoDB and send a Telegram message
with its information

The idea of having this as two separate jobs is to decouple the
obtention of information and its notification.

Additionally, while we currently only obtain the information from
Openbank, we are planning on extending this in the future with more Bank
integrations