### PR TITLE
Error fixing in RetrieveYesterdayTransactionsJob

### DIFF
--- a/app/jobs/finance/retrieve_yesterday_transactions_job.rb
+++ b/app/jobs/finance/retrieve_yesterday_transactions_job.rb
@@ -3,16 +3,22 @@
 module Finance
   class RetrieveYesterdayTransactionsJob < ::ApplicationJob
 
-    cron '27 01 * * ? *'
+    cron '27 03 * * ? *'
     def run
       openbank = Finance::Openbank::Service.new
-      transactions_data = openbank.get_transactions(Date.yesterday)
+      transactions_data = openbank.get_transactions(yesterday)
 
-      return if transactions_data.empty?
+      return if transactions_data.blank?
 
       transactions_data.each do |transaction_data|
         Finance::Openbank::TransactionBuilder.new(transaction_data).build
       end
+    end
+
+    private
+
+    def yesterday
+      DateTime.now.utc.yesterday.to_date
     end
   end
 end


### PR DESCRIPTION
Two changes:

1) Using `.blank?` instead of `.empty?` on `transactions_data`. This
will prevent errors if it's `nil` (see #25). While it doesn't address
the root cause, at least we mitigate the issue.

2) Modifying the date we retrieve transactions for to make sure that we use it on
UTC. As the Lambda will run on a time close to midnight, we want to be
sure that we don't have problems caused by timezones, so we'll get
yesterday's date after getting the current time in UTC