### PR TITLE
Openbank improvements + Metrics refactor

### DIFF
--- a/app/adapters/metrics/base_metric_adapter.rb
+++ b/app/adapters/metrics/base_metric_adapter.rb
@@ -2,18 +2,17 @@
 
 module Metrics
   class BaseMetricAdapter < Aws::CloudWatch::Types::MetricDatum
-    UNIT_COUNT = 'Count'
+    include Namespaces
+    include Units
 
-    def namespace
-      nil
-    end
+    attr_accessor :namespace
 
     def data
       self
     end
 
     def ==(other)
-      other.namespace == self.namespace &&
+      other.namespace == namespace &&
         other.metric_name == metric_name &&
         other.value == value &&
         other.timestamp == timestamp &&

--- a/app/adapters/metrics/finance/bank_transaction_metric_adapter.rb
+++ b/app/adapters/metrics/finance/bank_transaction_metric_adapter.rb
@@ -7,13 +7,10 @@ module Metrics
 
       def initialize(bank_transaction)
         self.metric_name = METRIC_NAME
+        self.namespace = FINANCE
         self.dimensions = [{ name: 'Bank', value: bank_transaction.bank }]
         self.timestamp = bank_transaction.datetime
         self.value = bank_transaction.amount
-      end
-
-      def namespace
-        'Finance'
       end
     end
   end

--- a/app/adapters/metrics/finance/bank_transaction_metric_adapter.rb
+++ b/app/adapters/metrics/finance/bank_transaction_metric_adapter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Metrics
+  module Finance
+    class BankTransactionMetricAdapter < BaseMetricAdapter
+      METRIC_NAME = 'BankTransaction'
+
+      def initialize(bank_transaction)
+        self.metric_name = METRIC_NAME
+        self.dimensions = [{ name: 'Bank', value: bank_transaction.bank }]
+        self.timestamp = bank_transaction.datetime
+        self.value = bank_transaction.amount
+      end
+
+      def namespace
+        'Finance'
+      end
+    end
+  end
+end

--- a/app/adapters/metrics/finance/expense_metric_adapter.rb
+++ b/app/adapters/metrics/finance/expense_metric_adapter.rb
@@ -12,13 +12,10 @@ module Metrics
 
       def initialize(expense)
         self.metric_name = METRIC_NAME
+        self.namespace = FINANCE
         self.dimensions = [{ name: 'Category', value: map_category(expense) }]
         self.timestamp = expense.created_at
         self.value = expense.amount.to_f
-      end
-
-      def namespace
-        'Finance'
       end
 
       private

--- a/app/adapters/metrics/health/injection_metric_adapter.rb
+++ b/app/adapters/metrics/health/injection_metric_adapter.rb
@@ -10,14 +10,11 @@ module Metrics
 
       def initialize(injection)
         self.metric_name = METRIC_NAME
+        self.namespace = HEALTH
         self.dimensions = [{ name: 'Type', value: map_injection_type(injection) }]
         self.timestamp = injection.created_at
         self.value = injection.units.to_f
-        self.unit = UNIT_COUNT
-      end
-
-      def namespace
-        'Health'
+        self.unit = COUNT
       end
 
       private

--- a/app/jobs/finance/retrieve_yesterday_transactions_job.rb
+++ b/app/jobs/finance/retrieve_yesterday_transactions_job.rb
@@ -10,15 +10,23 @@ module Finance
 
       return if transactions_data.empty?
 
-      transactions_data.each do |transaction_data|
-        Finance::Openbank::TransactionBuilder.new(transaction_data).build
-      end
+      transactions_data
+        .map { |transaction_data| create_bank_transaction(transaction_data) }
+        .each { |bank_transaction| publish_in_cloudwatch(bank_transaction) }
     end
 
     private
 
     def yesterday
       DateTime.now.utc.yesterday.to_date
+    end
+
+    def create_bank_transaction(transaction_data)
+      Finance::Openbank::TransactionBuilder.new(transaction_data).build
+    end
+
+    def publish_in_cloudwatch(bank_transaction)
+      PublishCloudwatchDataCommand.new(bank_transaction).execute
     end
   end
 end

--- a/app/jobs/finance/retrieve_yesterday_transactions_job.rb
+++ b/app/jobs/finance/retrieve_yesterday_transactions_job.rb
@@ -8,7 +8,7 @@ module Finance
       openbank = Finance::Openbank::Service.new
       transactions_data = openbank.get_transactions(yesterday)
 
-      return if transactions_data.blank?
+      return if transactions_data.empty?
 
       transactions_data.each do |transaction_data|
         Finance::Openbank::TransactionBuilder.new(transaction_data).build

--- a/app/models/finance/bank_transaction.rb
+++ b/app/models/finance/bank_transaction.rb
@@ -3,6 +3,7 @@
 module Finance
   class BankTransaction
     include Dynamoid::Document
+    include Metricable
 
     OPENBANK = 'Openbank'
     VALID_BANKS = [OPENBANK].freeze

--- a/app/models/metrics/base_metric.rb
+++ b/app/models/metrics/base_metric.rb
@@ -1,35 +1,11 @@
 # frozen_string_literal: true
 
 module Metrics
-  class BaseMetric < Aws::CloudWatch::Types::MetricDatum
-    UNIT_COUNT = 'Count'
+  class BaseMetric < BaseMetricAdapter
+    include Metricable
 
-    def namespace
-      nil
-    end
-
-    def data
+    def metric_adapter
       self
-    end
-
-    def ==(other)
-      other.namespace == self.namespace &&
-        other.metric_name == metric_name &&
-        other.value == value &&
-        other.timestamp == timestamp &&
-        compare_dimensions(other)
-    end
-
-    def contains_dimension?(other_dimension)
-      dimensions.any? { |dimension| dimension == other_dimension }
-    end
-
-    private
-
-    def compare_dimensions(other)
-      return false unless dimensions.size == other.dimensions.size
-
-      other.dimensions.all? { |dimension| contains_dimension?(dimension) }
     end
   end
 end

--- a/app/models/metrics/namespaces.rb
+++ b/app/models/metrics/namespaces.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Metrics
+  module Namespaces
+    FINANCE = 'Finance'
+    HEALTH = 'Health'
+    INFRASTRUCTURE = 'Infrastructure'
+  end
+end

--- a/app/models/metrics/units.rb
+++ b/app/models/metrics/units.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Metrics
+  module Units
+    COUNT = 'Count'
+  end
+end

--- a/spec/adapters/metrics/finance/bank_transaction_metric_adapter_spec.rb
+++ b/spec/adapters/metrics/finance/bank_transaction_metric_adapter_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Metrics::Finance::BankTransactionMetricAdapter do
+  let(:bank_transaction) { FactoryBot.create(:bank_transaction) }
+  let(:metric) { subject }
+
+  subject { described_class.new(bank_transaction) }
+
+  it 'sets the metric namespace' do
+    expect(metric.namespace).to eq 'Finance'
+  end
+
+  it 'sets the metric name' do
+    expect(metric.metric_name).to eq 'BankTransaction'
+  end
+
+  it 'sets the metric value' do
+    expect(metric.value).to eq 42
+  end
+
+  it 'sets the timestamp' do
+    expect(metric.timestamp).to eq bank_transaction.datetime
+  end
+
+  it 'sets only one dimension' do
+    expect(metric.dimensions.size).to eq 1
+  end
+
+  it 'sets the "Bank" dimension' do
+    dimension = metric.dimensions.first
+    expect(dimension[:name]).to eq 'Bank'
+    expect(dimension[:value]).to eq 'Openbank'
+  end
+end

--- a/spec/factories/finance/bank_transactions.rb
+++ b/spec/factories/finance/bank_transactions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bank_transaction, class: Finance::BankTransaction do
+    amount_in_cents { 4200 }
+    bank            { 'Openbank' }
+    datetime        { DateTime.now - 1.day }
+    description     { 'Expense on the universe, the meaning of life and everything else' }
+    internal_id     { 'BH095' }
+  end
+end

--- a/spec/fixtures/finance/openbank/get_movements_response.json
+++ b/spec/fixtures/finance/openbank/get_movements_response.json
@@ -54,7 +54,7 @@
                 }
             ],
             "conceptoTabla": "COMPRA EN PAYPAL *DAZN, CON LA TARJETA : XXXXXXXXXXXX4205 EL 2020-03-02                             ",
-            "fechaValor": "2020-03-04",
+            "fechaValor": "2020-03-03",
             "operacionDGO": {
                 "centro": {
                     "centro": "0100",
@@ -80,7 +80,7 @@
             },
             "indFinanciacion": "N",
             "contratoPrincipalOperacion": {
-                "numerodecontrato": "1980528",
+                "numerodecontrato": "1234567",
                 "centro": {
                     "centro": "0100",
                     "empresa": "0073"
@@ -89,7 +89,7 @@
             },
             "diaMvto": 99999,
             "nummov": 3,
-            "fechaOperacion": "2020-03-04"
+            "fechaOperacion": "2020-03-03"
         },
         {
             "recibo": false,
@@ -141,7 +141,7 @@
             },
             "indFinanciacion": "N",
             "contratoPrincipalOperacion": {
-                "numerodecontrato": "1980528",
+                "numerodecontrato": "1234567",
                 "centro": {
                     "centro": "0100",
                     "empresa": "0073"
@@ -208,7 +208,7 @@
             },
             "indFinanciacion": "N",
             "contratoPrincipalOperacion": {
-                "numerodecontrato": "1980528",
+                "numerodecontrato": "1234567",
                 "centro": {
                     "centro": "0100",
                     "empresa": "0073"
@@ -269,7 +269,7 @@
             },
             "indFinanciacion": "N",
             "contratoPrincipalOperacion": {
-                "numerodecontrato": "1980528",
+                "numerodecontrato": "1234567",
                 "centro": {
                     "centro": "0100",
                     "empresa": "0073"
@@ -282,7 +282,7 @@
         }
     ],
     "cuentaAsociada": {
-        "codbban": "00730100580555567850          ",
+        "codbban": "01821832022553151558          ",
         "digitodecontrol": "76",
         "pais": "ES"
     },

--- a/spec/fixtures/finance/openbank/movements.json
+++ b/spec/fixtures/finance/openbank/movements.json
@@ -1,0 +1,252 @@
+[
+    {
+        "recibo": false,
+        "subtipoContratoPrincipal": {
+            "subtipodeproducto": "002",
+            "tipodeproducto": {
+                "empresa": "0073",
+                "tipodeproducto": "506"
+            }
+        },
+        "categorias": [
+            {
+                "online": true,
+                "category": "Comercio y tiendas",
+                "subcategory": "Otros (Comercio y tiendas)",
+                "relevance": 0.99997959225225
+            },
+            {
+                "online": true,
+                "category": "Otros gastos",
+                "subcategory": "Otros gastos",
+                "relevance": 2.040774774997412E-5
+            }
+        ],
+        "conceptoTabla": "COMPRA EN PAYPAL *DAZN, CON LA TARJETA : XXXXXXXXXXXX4205 EL 2020-03-02                             ",
+        "fechaValor": "2020-03-03",
+        "operacionDGO": {
+            "centro": {
+                "centro": "0100",
+                "empresa": "0073"
+            },
+            "codigoterminaldgo": "BH027",
+            "numerodgo": 10226
+        },
+        "saldo": {
+            "divisa": "EUR",
+            "importe": 2395.47
+        },
+        "categoriaGanadora": {
+            "online": true,
+            "category": "Comercio y tiendas",
+            "subcategory": "Otros (Comercio y tiendas)",
+            "relevance": 0.99997959225225
+        },
+        "pendienteValoracion": false,
+        "importe": {
+            "divisa": "EUR",
+            "importe": -9.99
+        },
+        "indFinanciacion": "N",
+        "contratoPrincipalOperacion": {
+            "numerodecontrato": "1234567",
+            "centro": {
+                "centro": "0100",
+                "empresa": "0073"
+            },
+            "producto": "506"
+        },
+        "diaMvto": 99999,
+        "nummov": 3,
+        "fechaOperacion": "2020-03-03"
+    },
+    {
+        "recibo": false,
+        "subtipoContratoPrincipal": {
+            "subtipodeproducto": "002",
+            "tipodeproducto": {
+                "empresa": "0073",
+                "tipodeproducto": "506"
+            }
+        },
+        "categorias": [
+            {
+                "online": true,
+                "category": "Casa y hogar",
+                "subcategory": "Alimentación y supermercados",
+                "relevance": 0.9999803925403914
+            },
+            {
+                "online": true,
+                "category": "Otros gastos",
+                "subcategory": "Otros gastos",
+                "relevance": 1.960745960856689E-5
+            }
+        ],
+        "conceptoTabla": "COMPRA EN SUPERMAC'S, CON LA TARJETA : XXXXXXXXXXXX4205 EL 2020-03-01                               ",
+        "fechaValor": "2020-03-03",
+        "operacionDGO": {
+            "centro": {
+                "centro": "0100",
+                "empresa": "0073"
+            },
+            "codigoterminaldgo": "BH157",
+            "numerodgo": 14231
+        },
+        "saldo": {
+            "divisa": "EUR",
+            "importe": 2405.46
+        },
+        "categoriaGanadora": {
+            "online": true,
+            "category": "Casa y hogar",
+            "subcategory": "Alimentación y supermercados",
+            "relevance": 0.9999803925403914
+        },
+        "pendienteValoracion": false,
+        "importe": {
+            "divisa": "EUR",
+            "importe": -7.5
+        },
+        "indFinanciacion": "N",
+        "contratoPrincipalOperacion": {
+            "numerodecontrato": "1234567",
+            "centro": {
+                "centro": "0100",
+                "empresa": "0073"
+            },
+            "producto": "506"
+        },
+        "diaMvto": 99999,
+        "nummov": 3,
+        "fechaOperacion": "2020-03-03"
+    },
+    {
+        "recibo": false,
+        "subtipoContratoPrincipal": {
+            "subtipodeproducto": "002",
+            "tipodeproducto": {
+                "empresa": "0073",
+                "tipodeproducto": "506"
+            }
+        },
+        "categorias": [
+            {
+                "online": true,
+                "category": "Comercio y tiendas",
+                "subcategory": "Electrónica, libros, prensa, música y Apps",
+                "relevance": 0.9872820907588656
+            },
+            {
+                "online": true,
+                "category": "Casa y hogar",
+                "subcategory": "Telefonía, Internet y televisión",
+                "relevance": 0.012698163598381343
+            },
+            {
+                "online": true,
+                "category": "Otros gastos",
+                "subcategory": "Otros gastos",
+                "relevance": 1.9745642753044973E-5
+            }
+        ],
+        "conceptoTabla": "COMPRA EN GOOGLE*GOOGLE STORAGE, CON LA TARJETA : XXXXXXXXXXXX4205 EL 2020-02-29                    ",
+        "fechaValor": "2020-03-03",
+        "operacionDGO": {
+            "centro": {
+                "centro": "0100",
+                "empresa": "0073"
+            },
+            "codigoterminaldgo": "BH157",
+            "numerodgo": 14230
+        },
+        "saldo": {
+            "divisa": "EUR",
+            "importe": 2412.96
+        },
+        "categoriaGanadora": {
+            "online": true,
+            "category": "Comercio y tiendas",
+            "subcategory": "Electrónica, libros, prensa, música y Apps",
+            "relevance": 0.9872820907588656
+        },
+        "pendienteValoracion": false,
+        "importe": {
+            "divisa": "EUR",
+            "importe": -1.99
+        },
+        "indFinanciacion": "N",
+        "contratoPrincipalOperacion": {
+            "numerodecontrato": "1234567",
+            "centro": {
+                "centro": "0100",
+                "empresa": "0073"
+            },
+            "producto": "506"
+        },
+        "diaMvto": 2,
+        "nummov": 3,
+        "fechaOperacion": "2020-03-03"
+    },
+    {
+        "recibo": false,
+        "subtipoContratoPrincipal": {
+            "subtipodeproducto": "002",
+            "tipodeproducto": {
+                "empresa": "0073",
+                "tipodeproducto": "506"
+            }
+        },
+        "categorias": [
+            {
+                "online": true,
+                "category": "Comercio y tiendas",
+                "subcategory": "Otros (Comercio y tiendas)",
+                "relevance": 0.99997959225225
+            },
+            {
+                "online": true,
+                "category": "Otros gastos",
+                "subcategory": "Otros gastos",
+                "relevance": 2.040774774997412E-5
+            }
+        ],
+        "conceptoTabla": "COMPRA EN PAYPAL *ENEBA, CON LA TARJETA : XXXXXXXXXXXX4205 EL 2020-02-28                            ",
+        "fechaValor": "2020-03-03",
+        "operacionDGO": {
+            "centro": {
+                "centro": "0100",
+                "empresa": "0073"
+            },
+            "codigoterminaldgo": "BH157",
+            "numerodgo": 14229
+        },
+        "saldo": {
+            "divisa": "EUR",
+            "importe": 2414.95
+        },
+        "categoriaGanadora": {
+            "online": true,
+            "category": "Comercio y tiendas",
+            "subcategory": "Otros (Comercio y tiendas)",
+            "relevance": 0.99997959225225
+        },
+        "pendienteValoracion": false,
+        "importe": {
+            "divisa": "EUR",
+            "importe": -43.56
+        },
+        "indFinanciacion": "N",
+        "contratoPrincipalOperacion": {
+            "numerodecontrato": "1234567",
+            "centro": {
+                "centro": "0100",
+                "empresa": "0073"
+            },
+            "producto": "506"
+        },
+        "diaMvto": 1,
+        "nummov": 3,
+        "fechaOperacion": "2020-03-03"
+    }
+]

--- a/spec/fixtures/finance/openbank/no_movements.json
+++ b/spec/fixtures/finance/openbank/no_movements.json
@@ -1,0 +1,4 @@
+{
+    "error": "XX9511",
+    "errorDescription": "NINGUN REGISTRO CUMPLE LA CONDICION DE BUSQUEDA"
+}

--- a/spec/services/finance/openbank/service_spec.rb
+++ b/spec/services/finance/openbank/service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::Openbank::Service do
+  let(:openbank_credentials) do
+    {
+      OPENBANK_URL: 'https://fake.openbank.es',
+      OPENBANK_CONTRACT_NUMBER: '99',
+      OPENBANK_DOCUMENT: '30376334G',
+      OPENBANK_PASSWORD: '1234'
+    }
+  end
+
+  let(:auth_payload) { { document: '30376334G', password: '1234', documentType: 'N', force: true } }
+  let(:auth_response) { { tokenCredential: 'myToken', application: 'api' } }
+
+  let(:movements_payload) { { producto: '055', numeroContrato: 99, fechaDesde: '2020-05-02', fechaHasta: '2020-05-02' } }
+
+  let(:content_type_header) { { 'Content-Type'=> 'application/json' } }
+
+  let(:auth_request) do
+    stub_request(:post, 'https://fake.openbank.es/authenticationcomposite/login')
+      .with(body: auth_payload)
+  end
+  let(:movements_request) do
+    stub_request(:get, 'https://fake.openbank.es/my-money/cuentas/movimientos')
+      .with(query: movements_payload)
+  end
+
+  before do
+    travel_to Time.new(2020, 5, 3, 12, 34, 56)
+  end
+
+  around { |example| with_modified_env(openbank_credentials) { example.run } }
+
+  after { travel_back }
+
+  subject { described_class.new }
+
+  describe 'get_transactions' do
+    context 'when everything goes fine' do
+      let(:movements_response) { load_json_fixture 'finance/openbank/get_movements_response' }
+
+      before do
+        auth_request.to_return(status: 200, body: auth_response.to_json, headers: content_type_header)
+        movements_request.to_return(status: 200, body: movements_response.to_json, headers: content_type_header)
+      end
+
+      it 'retrieves the bank movements' do
+        expected_response = load_json_fixture('finance/openbank/movements')
+
+        result = subject.get_transactions(Date.yesterday)
+        expect(result).to eq expected_response
+      end
+    end
+
+    context 'when there are no new movements' do
+      let(:movements_response) { load_json_fixture 'finance/openbank/no_movements' }
+
+      before do
+        auth_request.to_return(status: 200, body: auth_response.to_json, headers: content_type_header)
+        movements_request.to_return(status: 404, body: movements_response.to_json, headers: content_type_header)
+      end
+
+      it 'returns an empty array' do
+        result = subject.get_transactions(Date.yesterday)
+        expect(result).to eq []
+      end
+    end
+
+    context 'when the request timeouts when reading' do
+      before do
+        auth_request.to_return(status: 200, body: auth_response.to_json, headers: content_type_header)
+        movements_request.to_raise(EOFError)
+      end
+
+      it 'retries 3 times' do
+        subject.get_transactions(Date.yesterday)
+
+        expect(movements_request).to have_been_made.times(4)
+      end
+
+      it 'returns an empty array' do
+        result = subject.get_transactions(Date.yesterday)
+        expect(result).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
This PR contains two main blocks of changes:

#### Openbank improvements
Solves #25. The problem was that, whenever there weren't any transactions, the
`movimientos` field wasn't present in the response. Now we'll prepare for it
by checking if the response code is a 404 and if that's the case we'll return an
empty array

Additionally, we did some fixes on the retry logic and improved the test coverage,
to be completely sure that it's working as expected.

Finally, we made `Finance::BankTransaction` implement `Metricable` and added a
metric to track the number of retries when calling Openbank

#### Metrics refactor
* Making `namespace` a field instead of a method
* Creating modules to encapsulate the definition of Units and Namespaces
* Converting `BaseMetric` in a Metricable that uses himself as the adapter

The idea of the last change is to allow us to simply publish metrics 
without having to create a new class for them. We just need to use a 
BaseMetric instance with the fields correctly populated