### PR TITLE
Integrating with Bankia

### DIFF
--- a/app/models/finance/bank_transaction.rb
+++ b/app/models/finance/bank_transaction.rb
@@ -5,8 +5,9 @@ module Finance
     include Dynamoid::Document
     include Metricable
 
+    BANKIA = 'Bankia'
     OPENBANK = 'Openbank'
-    VALID_BANKS = [OPENBANK].freeze
+    VALID_BANKS = [BANKIA, OPENBANK].freeze
 
     ERROR_BANK_INVALID = 'The specified bank is not allowed'
     ERROR_INTERNAL_ID_BLANK = 'internal_id cannot be blank if the bank is present'

--- a/app/services/finance/bankia/service.rb
+++ b/app/services/finance/bankia/service.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module Finance
+  module Bankia
+    class Service
+      FINTONIC_VERSION = 'application/vnd.fintonic-v7+json'
+
+      MAX_RETRIES = 3
+
+      def initialize
+        @retries = 0
+      end
+
+      def get_transactions(from, to = nil)
+        to ||= from
+
+        authenticate unless @auth_token
+
+        response = request_transactions(from, to)
+
+        if response.unauthorized?
+          authenticate
+          response = request_transactions(from, to)
+        end
+
+        # Note: when there are no movements for the specified date range, Fintonic
+        # returns movements anyway. To mimic this behavior, we'll return a
+        # response with movements on dates differents to the specified
+        response
+          .yield_self { |r| JSON.parse(r .body) }
+          .dig('resultList')
+          .select { |transaction| correct_date_range?(transaction, from, to) }
+      rescue EOFError
+        Jets.logger.warn "Error while retrieving bank transactions, retrying... Retry #: #{@retries}"
+
+        @retries += 1
+        retry unless @retries > MAX_RETRIES
+
+        Jets.logger.error('No more retries left, aborting')
+        []
+      ensure
+        publish_retry_metric
+      end
+
+      private
+
+      def request_transactions(from, to)
+        HTTParty.get(
+          transactions_endpoint,
+          headers: transactions_headers,
+          query: transactions_payload(from, to)
+        )
+      end
+
+      def transactions_endpoint
+        "#{base_url}/finapi/rest/transaction/listByBank/2038"
+      end
+
+      def base_url
+        @base_url ||= ENV['FINTONIC_URL']
+      end
+
+      def transactions_headers
+        {
+          'device-uuid': device_uuid,
+          'Accept': FINTONIC_VERSION,
+          'Authorization': "Bearer #{@auth_token}"
+        }
+      end
+
+      def transactions_payload(from, to)
+        from_formatted = from.strftime('%Y-%m-%d')
+        to_formatted = to.strftime('%Y-%m-%d')
+
+        {
+          pageLimit: 25,
+          startDate: from_formatted,
+          endDate: to_formatted,
+          pageOffset: 0
+        }
+      end
+
+      def correct_date_range?(transaction, from, to)
+        transaction_date = Date.parse(transaction.dig('userDate'))
+        date_range = from..to
+
+        date_range.cover? transaction_date
+      end
+
+      def authenticate
+        response = HTTParty.post(auth_endpoint, headers: auth_headers, body: auth_payload.to_json)
+        response_body = JSON.parse(response.body)
+
+        @auth_token = response_body.dig('data', 'access_token')
+      end
+
+      def auth_endpoint
+        "#{base_url}/finapi/oidc/token"
+      end
+
+      def auth_headers
+        {
+          'Accept' => FINTONIC_VERSION,
+          'Content-Type' => 'application/json',
+        }
+      end
+
+      def auth_payload
+        {
+          username: username,
+          password: password,
+          deviceUUID: device_uuid
+        }
+      end
+
+      def username
+        @username ||= ENV['FINTONIC_USERNAME']
+      end
+
+      def password
+        @password ||= ENV['FINTONIC_PASSWORD']
+      end
+
+      def device_uuid
+        @device_uuid ||= ENV['FINTONIC_DEVICE_UUID']
+      end
+
+      def publish_retry_metric
+        retry_metric = Metrics::BaseMetric.new
+        retry_metric.namespace = "#{Metrics::Namespaces::INFRASTRUCTURE}/#{Metrics::Namespaces::FINANCE}/Fintonic"
+        retry_metric.metric_name = 'get_transactions retries'
+        retry_metric.unit = Metrics::Units::COUNT
+        retry_metric.value = @retries
+        retry_metric.timestamp = DateTime.now
+        retry_metric.dimensions = []
+
+        PublishCloudwatchDataCommand.new(retry_metric).execute
+      end
+    end
+  end
+end

--- a/app/services/finance/bankia/transaction_builder.rb
+++ b/app/services/finance/bankia/transaction_builder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Finance
+  module Bankia
+    class TransactionBuilder < ::Finance::BaseTransactionBuilder
+      private
+
+      def amount_in_cents
+        @transaction_information['quantity']
+      end
+
+      def bank
+        'Bankia'
+      end
+
+      def internal_id
+        @transaction_information['id']
+      end
+
+      def transaction_datetime
+        Date.parse(@transaction_information['userDate'])
+      end
+
+      def description
+        @transaction_information['description']
+      end
+    end
+  end
+end

--- a/spec/fixtures/finance/fintonic/auth_response_success.json
+++ b/spec/fixtures/finance/fintonic/auth_response_success.json
@@ -1,0 +1,13 @@
+{
+    "data": {
+        "id_token": "id_token",
+        "token_type": "bearer",
+        "access_token": "access_token",
+        "expires_in": 1800,
+        "refresh_expires_in": 1800,
+        "refresh_token": "refresh_token",
+        "not-before-policy": 12345567,
+        "session_state": "02c49d73-c76a-4f83-1234-abcdef123456",
+        "scope": "openid profile email"
+    }
+}

--- a/spec/fixtures/finance/fintonic/bankia_movements.json
+++ b/spec/fixtures/finance/fintonic/bankia_movements.json
@@ -1,0 +1,78 @@
+[
+    {
+        "bankId": "2038",
+        "systemBankId": "2038",
+        "active": true,
+        "id": "5ebf41844afb2e1e7d3e7ea4",
+        "type": "ACCOUNT",
+        "productId": "3221",
+        "description": "Kindle Svcs*N59P04SY5 - Kindle Svcs*N59P04SY5",
+        "reference": "COMPRA COMERCIO",
+        "note": null,
+        "userDescription": null,
+        "read": false,
+        "quantity": -171,
+        "currency": "EURO",
+        "baseQuantity": -171,
+        "baseCurrency": "EURO",
+        "valueDate": "2020-05-02",
+        "userDate": "2020-05-02",
+        "operationDate": "2020-05-13",
+        "cleanNote": "KINDLE SVCS*N59P04SY5 - KINDLE SVCS*N59P04SY5",
+        "cleanUserDescription": "COMERCIO",
+        "offer": null,
+        "categorization": {
+            "weightedCategories": {
+                "G0606": -171
+            },
+            "firedRuleId": "MULTILABEL",
+            "classified": true,
+            "categorizedByClient": false,
+            "categorizedByUserRule": false,
+            "categorizedBySystem": true,
+            "splited": false
+        },
+        "customAction": null,
+        "transactionCustomActionClick": null,
+        "primaryDisplay": "Kindle svcs*n59p04sy5 - kindle svcs*n59p04sy5",
+        "secondaryDisplay": "Comercio"
+    },
+    {
+        "bankId": "2038",
+        "systemBankId": "2038",
+        "active": true,
+        "id": "5ebf43a0eafb288bed3e7ea5",
+        "type": "ACCOUNT",
+        "productId": "3221",
+        "description": "ABONO A COMPRADOR POR DEVOLUCION - Kindle Svcs",
+        "reference": "DEVOLUCION COMERCIO",
+        "note": null,
+        "userDescription": null,
+        "read": false,
+        "quantity": 171,
+        "currency": "EURO",
+        "baseQuantity": 171,
+        "baseCurrency": "EURO",
+        "valueDate": "2020-05-02",
+        "userDate": "2020-05-02",
+        "operationDate": "2020-05-13",
+        "cleanNote": "ABONO A COMPRADOR POR DEVOLUCION - KINDLE SVCS",
+        "cleanUserDescription": "DEVOLUCION COMERCIO",
+        "offer": null,
+        "categorization": {
+            "weightedCategories": {
+                "G0408": 171
+            },
+            "firedRuleId": "MULTILABEL",
+            "classified": true,
+            "categorizedByClient": false,
+            "categorizedByUserRule": false,
+            "categorizedBySystem": true,
+            "splited": false
+        },
+        "customAction": null,
+        "transactionCustomActionClick": null,
+        "primaryDisplay": "Abono a comprador por devolucion - kindle svcs",
+        "secondaryDisplay": "Devolucion comercio"
+    }
+]

--- a/spec/fixtures/finance/fintonic/bankia_transactions_response_no_movements.json
+++ b/spec/fixtures/finance/fintonic/bankia_transactions_response_no_movements.json
@@ -1,0 +1,119 @@
+{
+    "count": 0,
+    "resultList": [
+        {
+            "bankId": "2038",
+            "systemBankId": "2038",
+            "active": true,
+            "id": "5ebf41844afb2e1e7d3e7ea4",
+            "type": "ACCOUNT",
+            "productId": "3221",
+            "description": "Kindle Svcs*N59P04SY5 - Kindle Svcs*N59P04SY5",
+            "reference": "COMPRA COMERCIO",
+            "note": null,
+            "userDescription": null,
+            "read": false,
+            "quantity": -171,
+            "currency": "EURO",
+            "baseQuantity": -171,
+            "baseCurrency": "EURO",
+            "valueDate": "2020-05-15",
+            "userDate": "2020-05-15",
+            "operationDate": "2020-05-13",
+            "cleanNote": "KINDLE SVCS*N59P04SY5 - KINDLE SVCS*N59P04SY5",
+            "cleanUserDescription": "COMERCIO",
+            "offer": null,
+            "categorization": {
+                "weightedCategories": {
+                    "G0606": -171
+                },
+                "firedRuleId": "MULTILABEL",
+                "classified": true,
+                "categorizedByClient": false,
+                "categorizedByUserRule": false,
+                "categorizedBySystem": true,
+                "splited": false
+            },
+            "customAction": null,
+            "transactionCustomActionClick": null,
+            "primaryDisplay": "Kindle svcs*n59p04sy5 - kindle svcs*n59p04sy5",
+            "secondaryDisplay": "Comercio"
+        },
+        {
+            "bankId": "2038",
+            "systemBankId": "2038",
+            "active": true,
+            "id": "5ebf43a0eafb288bed3e7ea5",
+            "type": "ACCOUNT",
+            "productId": "3221",
+            "description": "ABONO A COMPRADOR POR DEVOLUCION - Kindle Svcs",
+            "reference": "DEVOLUCION COMERCIO",
+            "note": null,
+            "userDescription": null,
+            "read": false,
+            "quantity": 171,
+            "currency": "EURO",
+            "baseQuantity": 171,
+            "baseCurrency": "EURO",
+            "valueDate": "2020-05-15",
+            "userDate": "2020-05-15",
+            "operationDate": "2020-05-13",
+            "cleanNote": "ABONO A COMPRADOR POR DEVOLUCION - KINDLE SVCS",
+            "cleanUserDescription": "DEVOLUCION COMERCIO",
+            "offer": null,
+            "categorization": {
+                "weightedCategories": {
+                    "G0408": 171
+                },
+                "firedRuleId": "MULTILABEL",
+                "classified": true,
+                "categorizedByClient": false,
+                "categorizedByUserRule": false,
+                "categorizedBySystem": true,
+                "splited": false
+            },
+            "customAction": null,
+            "transactionCustomActionClick": null,
+            "primaryDisplay": "Abono a comprador por devolucion - kindle svcs",
+            "secondaryDisplay": "Devolucion comercio"
+        },
+        {
+            "bankId": "2038",
+            "systemBankId": "2038",
+            "active": true,
+            "id": "5e924063ca11630878c31c4e",
+            "type": "ACCOUNT",
+            "productId": "3221",
+            "description": "PEPEMOBILE, S.L.",
+            "reference": "202090001470186 SERV. PEPEPHONE.COM N.20",
+            "note": null,
+            "userDescription": null,
+            "read": true,
+            "quantity": -1990,
+            "currency": "EURO",
+            "baseQuantity": -1990,
+            "baseCurrency": "EURO",
+            "valueDate": "2020-04-07",
+            "userDate": "2020-04-07",
+            "operationDate": "2020-04-07",
+            "cleanNote": null,
+            "cleanUserDescription": null,
+            "offer": null,
+            "categorization": {
+                "weightedCategories": {
+                    "G0402": -1990
+                },
+                "firedRuleId": "MULTILABEL",
+                "classified": true,
+                "categorizedByClient": false,
+                "categorizedByUserRule": false,
+                "categorizedBySystem": true,
+                "splited": false
+            },
+            "customAction": null,
+            "transactionCustomActionClick": null,
+            "primaryDisplay": "Pepemobile, s.l.",
+            "secondaryDisplay": "202090001470186 serv. pepephone.com n.20"
+        }
+    ]
+}

--- a/spec/fixtures/finance/fintonic/bankia_transactions_response_success.json
+++ b/spec/fixtures/finance/fintonic/bankia_transactions_response_success.json
@@ -1,0 +1,81 @@
+{
+    "count": 0,
+    "resultList": [
+        {
+            "bankId": "2038",
+            "systemBankId": "2038",
+            "active": true,
+            "id": "5ebf41844afb2e1e7d3e7ea4",
+            "type": "ACCOUNT",
+            "productId": "3221",
+            "description": "Kindle Svcs*N59P04SY5 - Kindle Svcs*N59P04SY5",
+            "reference": "COMPRA COMERCIO",
+            "note": null,
+            "userDescription": null,
+            "read": false,
+            "quantity": -171,
+            "currency": "EURO",
+            "baseQuantity": -171,
+            "baseCurrency": "EURO",
+            "valueDate": "2020-05-02",
+            "userDate": "2020-05-02",
+            "operationDate": "2020-05-13",
+            "cleanNote": "KINDLE SVCS*N59P04SY5 - KINDLE SVCS*N59P04SY5",
+            "cleanUserDescription": "COMERCIO",
+            "offer": null,
+            "categorization": {
+                "weightedCategories": {
+                    "G0606": -171
+                },
+                "firedRuleId": "MULTILABEL",
+                "classified": true,
+                "categorizedByClient": false,
+                "categorizedByUserRule": false,
+                "categorizedBySystem": true,
+                "splited": false
+            },
+            "customAction": null,
+            "transactionCustomActionClick": null,
+            "primaryDisplay": "Kindle svcs*n59p04sy5 - kindle svcs*n59p04sy5",
+            "secondaryDisplay": "Comercio"
+        },
+        {
+            "bankId": "2038",
+            "systemBankId": "2038",
+            "active": true,
+            "id": "5ebf43a0eafb288bed3e7ea5",
+            "type": "ACCOUNT",
+            "productId": "3221",
+            "description": "ABONO A COMPRADOR POR DEVOLUCION - Kindle Svcs",
+            "reference": "DEVOLUCION COMERCIO",
+            "note": null,
+            "userDescription": null,
+            "read": false,
+            "quantity": 171,
+            "currency": "EURO",
+            "baseQuantity": 171,
+            "baseCurrency": "EURO",
+            "valueDate": "2020-05-02",
+            "userDate": "2020-05-02",
+            "operationDate": "2020-05-13",
+            "cleanNote": "ABONO A COMPRADOR POR DEVOLUCION - KINDLE SVCS",
+            "cleanUserDescription": "DEVOLUCION COMERCIO",
+            "offer": null,
+            "categorization": {
+                "weightedCategories": {
+                    "G0408": 171
+                },
+                "firedRuleId": "MULTILABEL",
+                "classified": true,
+                "categorizedByClient": false,
+                "categorizedByUserRule": false,
+                "categorizedBySystem": true,
+                "splited": false
+            },
+            "customAction": null,
+            "transactionCustomActionClick": null,
+            "primaryDisplay": "Abono a comprador por devolucion - kindle svcs",
+            "secondaryDisplay": "Devolucion comercio"
+        }
+    ]
+}

--- a/spec/services/finance/bankia/service_spec.rb
+++ b/spec/services/finance/bankia/service_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::Bankia::Service do
+  let(:credentials) do
+    {
+      FINTONIC_URL: 'https://fake.fintonic.es',
+      FINTONIC_USERNAME: 'username@gmail.com',
+      FINTONIC_PASSWORD: 'password',
+      FINTONIC_DEVICE_UUID: 'ef260964-8040-4fbb-8504-a9030ddef0b5'
+    }
+  end
+
+  let(:auth_headers) { { 'Accept' => 'application/vnd.fintonic-v7+json', 'Content-Type' => 'application/json' } }
+  let(:auth_payload) { { username: 'username@gmail.com', password: 'password', deviceUUID: 'ef260964-8040-4fbb-8504-a9030ddef0b5' } }
+  let(:auth_response) { load_json_fixture 'finance/fintonic/auth_response_success' }
+  let(:auth_request) do
+    stub_request(:post, 'https://fake.fintonic.es/finapi/oidc/token')
+      .with(headers: auth_headers, body: auth_payload)
+  end
+
+  let(:transactions_headers) { { 'device-uuid' => 'ef260964-8040-4fbb-8504-a9030ddef0b5', 'Accept': 'application/vnd.fintonic-v7+json', 'Authorization': 'Bearer access_token' } }
+  let(:transactions_payload) { { startDate: '2020-05-02', endDate: '2020-05-02', pageLimit: 25, pageOffset: 0 } }
+  let(:transactions_response) { load_json_fixture 'finance/fintonic/bankia_transactions_response_success' }
+  let(:transactions_request) do
+    stub_request(:get, 'https://fake.fintonic.es/finapi/rest/transaction/listByBank/2038')
+      .with(headers: transactions_headers, query: transactions_payload)
+  end
+
+  let(:retries_metric) do
+    retry_metric = Metrics::BaseMetric.new
+    retry_metric.namespace = "Infrastructure/Finance/Fintonic"
+    retry_metric.metric_name = 'get_transactions retries'
+    retry_metric.unit = 'Count'
+    retry_metric.value = expected_retries
+    retry_metric.timestamp = Time.new(2020, 5, 3, 12, 34, 56)
+    retry_metric.dimensions = []
+
+    retry_metric
+  end
+
+  before do
+    travel_to Time.new(2020, 5, 3, 12, 34, 56)
+    stub_command PublishCloudwatchDataCommand
+  end
+
+  around { |example| with_modified_env(credentials) { example.run } }
+
+  after { travel_back }
+
+  subject { described_class.new.get_transactions(Date.yesterday) }
+
+  describe 'get_transactions' do
+    context 'when everything goes fine' do
+      before do
+        auth_request.to_return(status: 200, body: auth_response.to_json, headers: auth_headers)
+        transactions_request.to_return(status: 200, body: transactions_response.to_json)
+      end
+
+      it 'retrieves the bank movements' do
+        expected_response = load_json_fixture('finance/fintonic/bankia_movements')
+
+        result = subject
+        expect(result).to eq expected_response
+      end
+
+      include_examples 'retry metric', 0
+    end
+
+    context 'when there are no new movements' do
+      before do
+        # Note: when there are no movements for the specified date range, Fintonic
+        # returns movements anyway. To mimic this behavior, we'll return a
+        # response with movements on dates differents to the specified
+        auth_request.to_return(status: 200, body: auth_response.to_json, headers: auth_headers)
+        transactions_request.to_return(status: 200, body: transactions_response.to_json)
+      end
+
+      let(:transactions_response) { load_json_fixture 'finance/fintonic/bankia_transactions_response_no_movements' }
+
+      it 'returns an empty array' do
+        result = subject
+        expect(result).to eq []
+      end
+
+      include_examples 'retry metric', 0
+    end
+
+    context 'when the request timeouts when reading' do
+      before do
+        auth_request.to_return(status: 200, body: auth_response.to_json, headers: auth_headers)
+        transactions_request.to_raise(EOFError)
+      end
+
+      it 'returns an empty array' do
+        result = subject
+        expect(result).to eq []
+      end
+
+      it 'retries 3 times' do
+        subject
+
+        expect(transactions_request).to have_been_made.times(4)
+      end
+
+      include_examples 'retry metric', 4
+    end
+  end
+end

--- a/spec/services/finance/openbank/service_spec.rb
+++ b/spec/services/finance/openbank/service_spec.rb
@@ -49,16 +49,6 @@ RSpec.describe Finance::Openbank::Service do
 
   subject { described_class.new.get_transactions(Date.yesterday) }
 
-  RSpec.shared_examples 'retry metric' do |retries|
-    let(:expected_retries) { retries }
-
-    it 'publishes a metric with the retries' do
-      expect(PublishCloudwatchDataCommand).to receive(:new).with(retries_metric)
-
-      subject
-    end
-  end
-
   describe 'get_transactions' do
     context 'when everything goes fine' do
       let(:movements_response) { load_json_fixture 'finance/openbank/get_movements_response' }

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,5 +1,5 @@
-RSpec.shared_examples 'retry metric' do |retries| let(:expected_retries) { retries }
-  let (:expected_retries) { retries }
+RSpec.shared_examples 'retry metric' do |retries|
+  let(:expected_retries) { retries }
 
   it 'publishes a metric with the retries' do
     expect(PublishCloudwatchDataCommand).to receive(:new).with(retries_metric)

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'retry metric' do |retries| let(:expected_retries) { retries }
+  let (:expected_retries) { retries }
+
+  it 'publishes a metric with the retries' do
+    expect(PublishCloudwatchDataCommand).to receive(:new).with(retries_metric)
+
+    subject
+  end
+end


### PR DESCRIPTION
### Description
Adding logic to also retrieve bank movements from Bankia. They will be retrieved in the same job where we are retrieving Openbank's transactions

As integrating with Bankia directly is quite complex, we are retrieving the movements via Fintonic. Still, the class structure doesn't make any mention to it to make this completely transparent to the rest of the codebase.

The logic follows the same interface that we used for retrieving movements from Openbank, to make it easier to abstract the logic in the future in case we want to. In fact, we already modified the Finance::RetrieveYesterdayTransactionsJob code to automatically infer the classes that we'll be using