### PR TITLE
Add new index depending on transaction date

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@ Rake::Task.define_task(:environment)
 require 'dynamoid/tasks'
 require 'jets'
 
-Dir.glob("#{Jets.root}/lib/tasks/*.rake").each { |r| import r }
+Dir.glob("#{Jets.root}/lib/tasks/**/*.rake").each { |r| import r }
 
 Jets.load_tasks

--- a/app/jobs/finance/notify_yesterday_transactions_job.rb
+++ b/app/jobs/finance/notify_yesterday_transactions_job.rb
@@ -13,7 +13,12 @@ module Finance
     private
 
     def yesterday_transactions
-      @yesterday_transactions ||= Finance::BankTransaction.where('datetime.gte': Date.yesterday).to_a
+      yesterday = Date.yesterday
+
+      @yesterday_transactions ||=
+        Finance::BankTransaction
+          .where('year_month': yesterday.strftime('%Y-%m'), 'day.gte': yesterday.strftime('%d'))
+          .to_a
     end
 
     def telegram_message

--- a/app/models/finance/bank_transaction.rb
+++ b/app/models/finance/bank_transaction.rb
@@ -18,6 +18,11 @@ module Finance
     field :description, :string
     field :internal_id, :string
 
+    # Indexes
+    field :year_month, :string
+    field :day, :string
+
+    global_secondary_index hash_key: :year_month, range_key: :day, projected_attributes: :all, name: 'transaction_date', read_capacity: 1, write_capacity: 1
     global_secondary_index hash_key: :internal_id
 
     validates_presence_of :amount_in_cents

--- a/app/services/finance/base_transaction_builder.rb
+++ b/app/services/finance/base_transaction_builder.rb
@@ -16,12 +16,24 @@ module Finance
         bank: bank,
         internal_id: internal_id,
         datetime: transaction_datetime,
-        description: description
+        description: description,
+        year_month: year_month,
+        day: day
       )
 
       transaction.save!
 
       transaction
+    end
+
+    private
+
+    def year_month
+      transaction_datetime.strftime('%Y-%m')
+    end
+
+    def day
+      transaction_datetime.strftime('%d')
     end
   end
 end

--- a/lib/tasks/temp/20200719_create_bank_transaction_index.rake
+++ b/lib/tasks/temp/20200719_create_bank_transaction_index.rake
@@ -1,0 +1,58 @@
+namespace :temp do
+  desc 'Update the BankTransactions table and create an index on the transaction date'
+  task bank_transaction_update_and_index: :environment do
+    client = Aws::DynamoDB::Client.new
+    table_name = Finance::BankTransaction.table_name
+
+    client.update_table(
+      table_name: table_name,
+      attribute_definitions: [
+        {
+          attribute_name: 'year_month',
+          attribute_type: 'S',
+        },
+        {
+          attribute_name: 'day',
+          attribute_type: 'S'
+        }
+      ],
+      global_secondary_index_updates: [{
+        create: {
+          index_name: 'transaction_date',
+          key_schema: [
+            {
+              key_type: 'HASH',
+              attribute_name: 'year_month'
+            },
+            {
+              key_type: 'RANGE',
+              attribute_name: 'day'
+            }
+          ],
+          projection: {
+            projection_type: 'ALL'
+          },
+          provisioned_throughput: {
+            read_capacity_units: 1,
+            write_capacity_units: 1
+          },
+        }
+      }]
+    )
+
+    errors = 0
+    Finance::BankTransaction.batch(50).each do |bank_transaction|
+      # Give some time to DynamoDB to avoid getting exceeded capacity errors
+      sleep(0.01)
+
+      bank_transaction.year_month = bank_transaction.datetime.strftime('%Y-%m')
+      bank_transaction.day = bank_transaction.datetime.strftime('%d')
+      bank_transaction.save!
+    rescue e
+      errors += 1      
+      puts "Error: #{e}"
+    end
+
+    puts "Encountered #{errors} errors while updating existing BankTransactions"
+  end
+end

--- a/spec/fixtures/finance/fintonic/bankia_movement.json
+++ b/spec/fixtures/finance/fintonic/bankia_movement.json
@@ -1,0 +1,38 @@
+{
+    "bankId": "2038",
+    "systemBankId": "2038",
+    "active": true,
+    "id": "5ebf41844afb2e1e7d3e7ea4",
+    "type": "ACCOUNT",
+    "productId": "3221",
+    "description": "Kindle Svcs*N59P04SY5 - Kindle Svcs*N59P04SY5",
+    "reference": "COMPRA COMERCIO",
+    "note": null,
+    "userDescription": null,
+    "read": false,
+    "quantity": -171,
+    "currency": "EURO",
+    "baseQuantity": -171,
+    "baseCurrency": "EURO",
+    "valueDate": "2020-05-02",
+    "userDate": "2020-05-02",
+    "operationDate": "2020-05-13",
+    "cleanNote": "KINDLE SVCS*N59P04SY5 - KINDLE SVCS*N59P04SY5",
+    "cleanUserDescription": "COMERCIO",
+    "offer": null,
+    "categorization": {
+        "weightedCategories": {
+            "G0606": -171
+        },
+        "firedRuleId": "MULTILABEL",
+        "classified": true,
+        "categorizedByClient": false,
+        "categorizedByUserRule": false,
+        "categorizedBySystem": true,
+        "splited": false
+    },
+    "customAction": null,
+    "transactionCustomActionClick": null,
+    "primaryDisplay": "Kindle svcs*n59p04sy5 - kindle svcs*n59p04sy5",
+    "secondaryDisplay": "Comercio"
+}

--- a/spec/fixtures/finance/openbank/movement.json
+++ b/spec/fixtures/finance/openbank/movement.json
@@ -1,0 +1,61 @@
+{
+    "recibo": false,
+    "subtipoContratoPrincipal": {
+        "subtipodeproducto": "002",
+        "tipodeproducto": {
+            "empresa": "0073",
+            "tipodeproducto": "506"
+        }
+    },
+    "categorias": [
+        {
+            "online": true,
+            "category": "Comercio y tiendas",
+            "subcategory": "Otros (Comercio y tiendas)",
+            "relevance": 0.99997959225225
+        },
+        {
+            "online": true,
+            "category": "Otros gastos",
+            "subcategory": "Otros gastos",
+            "relevance": 2.040774774997412E-5
+        }
+    ],
+    "conceptoTabla": "COMPRA EN PAYPAL *DAZN, CON LA TARJETA : XXXXXXXXXXXX4205 EL 2020-03-02                             ",
+    "fechaValor": "2020-03-03",
+    "operacionDGO": {
+        "centro": {
+            "centro": "0100",
+            "empresa": "0073"
+        },
+        "codigoterminaldgo": "BH027",
+        "numerodgo": 10226
+    },
+    "saldo": {
+        "divisa": "EUR",
+        "importe": 2395.47
+    },
+    "categoriaGanadora": {
+        "online": true,
+        "category": "Comercio y tiendas",
+        "subcategory": "Otros (Comercio y tiendas)",
+        "relevance": 0.99997959225225
+    },
+    "pendienteValoracion": false,
+    "importe": {
+        "divisa": "EUR",
+        "importe": -9.99
+    },
+    "indFinanciacion": "N",
+    "contratoPrincipalOperacion": {
+        "numerodecontrato": "1234567",
+        "centro": {
+            "centro": "0100",
+            "empresa": "0073"
+        },
+        "producto": "506"
+    },
+    "diaMvto": 99999,
+    "nummov": 3,
+    "fechaOperacion": "2020-03-03"
+}

--- a/spec/services/finance/bankia/transaction_builder_spec.rb
+++ b/spec/services/finance/bankia/transaction_builder_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::Bankia::TransactionBuilder do
+  let(:transaction_information) { load_json_fixture 'finance/fintonic/bankia_movement' }
+
+  describe '#build' do
+    subject(:bank_transaction) { described_class.new(transaction_information).build }
+
+    it 'sets the amount_in_cents' do
+      expect(bank_transaction.amount_in_cents).to eq -171
+    end
+
+    it 'sets the bank' do
+      expect(bank_transaction.bank).to eq 'Bankia'
+    end
+
+    it 'sets the datetime' do
+      expect(bank_transaction.datetime).to eq Date.parse('2020-05-02')
+    end
+
+    it 'sets the description' do
+      expect(bank_transaction.description).to eq 'Kindle Svcs*N59P04SY5 - Kindle Svcs*N59P04SY5'
+    end
+
+    it 'sets the internal_id' do
+      expect(bank_transaction.internal_id).to eq '5ebf41844afb2e1e7d3e7ea4'
+    end
+  end
+end

--- a/spec/services/finance/bankia/transaction_builder_spec.rb
+++ b/spec/services/finance/bankia/transaction_builder_spec.rb
@@ -25,5 +25,13 @@ RSpec.describe Finance::Bankia::TransactionBuilder do
     it 'sets the internal_id' do
       expect(bank_transaction.internal_id).to eq '5ebf41844afb2e1e7d3e7ea4'
     end
+
+    it 'sets year_month' do
+      expect(bank_transaction.year_month).to eq '2020-05'
+    end
+
+    it 'sets day' do
+      expect(bank_transaction.day).to eq '02'
+    end
   end
 end

--- a/spec/services/finance/openbank/transaction_builder_spec.rb
+++ b/spec/services/finance/openbank/transaction_builder_spec.rb
@@ -25,5 +25,13 @@ RSpec.describe Finance::Openbank::TransactionBuilder do
     it 'sets the internal_id' do
       expect(bank_transaction.internal_id).to eq 'BH027_10226'
     end
+
+    it 'sets year_month' do
+      expect(bank_transaction.year_month).to eq '2020-03'
+    end
+
+    it 'sets day' do
+      expect(bank_transaction.day).to eq '03'
+    end
   end
 end

--- a/spec/services/finance/openbank/transaction_builder_spec.rb
+++ b/spec/services/finance/openbank/transaction_builder_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::Openbank::TransactionBuilder do
+  let(:transaction_information) { load_json_fixture 'finance/openbank/movement' }
+
+  describe '#build' do
+    subject(:bank_transaction) { described_class.new(transaction_information).build }
+
+    it 'sets the amount_in_cents' do
+      expect(bank_transaction.amount_in_cents).to eq -999
+    end
+
+    it 'sets the bank' do
+      expect(bank_transaction.bank).to eq 'Openbank'
+    end
+
+    it 'sets the datetime' do
+      expect(bank_transaction.datetime).to eq Date.parse('2020-03-03')
+    end
+
+    it 'sets the description' do
+      expect(bank_transaction.description).to eq 'COMPRA EN PAYPAL *DAZN, CON LA TARJETA : XXXXXXXXXXXX4205 EL 2020-03-02'
+    end
+
+    it 'sets the internal_id' do
+      expect(bank_transaction.internal_id).to eq 'BH027_10226'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #27

### Description
Creates two new fields, `year_month` and `day`, to be able to group better
the BankTransaction objects. We'll use `year_month` as the hash key for the
index and `day` as the range key. As we have approximately the same number
of transactions per month, this will prevent hot partition problems

### Links
- [AWS docs on DynamoDB Global Secondary Indexes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html) 
- [AWS SDK for Ruby - DynamoDB table update docs](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/DynamoDB/Table.html#update-instance_method)
- [Dynamoid issue confirming that there is no way of creating an index automatically](https://github.com/Dynamoid/dynamoid/issues/443)
