### PR TITLE
Retrieving AIB transactions

### DIFF
--- a/app/jobs/finance/retrieve_yesterday_transactions_job.rb
+++ b/app/jobs/finance/retrieve_yesterday_transactions_job.rb
@@ -3,7 +3,7 @@
 module Finance
   class RetrieveYesterdayTransactionsJob < ::ApplicationJob
 
-    BANKS = %w[Bankia Openbank].freeze
+    BANKS = %w[Aib Bankia Openbank].freeze
 
     cron '27 03 * * ? *'
     def run

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class InvalidTokenProvider < StandardError; end
+
+class AuthToken
+  include Dynamoid::Document
+
+  PROVIDER_AIB = :aib
+  PROVIDER_DEXCOM = :dexcom
+  PROVIDERS = [PROVIDER_AIB, PROVIDER_DEXCOM].freeze
+
+  field :authorization_code, :string
+  field :access_token, :string
+  field :expiration_time, :number
+  field :refresh_token, :string
+  field :provider, :string
+
+  global_secondary_index hash_key: :provider, projected_attributes: :all, name: 'provider_index', read_capacity: 1, write_capacity: 1
+
+  def self.token_for(provider)
+    raise InvalidTokenProvider unless PROVIDERS.include? provider
+
+    tokens_for_provider = where(provider: provider)
+
+    tokens_for_provider.first || create(provider: provider)
+  end
+end

--- a/app/models/finance/bank_transaction.rb
+++ b/app/models/finance/bank_transaction.rb
@@ -5,9 +5,10 @@ module Finance
     include Dynamoid::Document
     include Metricable
 
+    AIB = 'AIB'
     BANKIA = 'Bankia'
     OPENBANK = 'Openbank'
-    VALID_BANKS = [BANKIA, OPENBANK].freeze
+    VALID_BANKS = [AIB, BANKIA, OPENBANK].freeze
 
     ERROR_BANK_INVALID = 'The specified bank is not allowed'
     ERROR_INTERNAL_ID_BLANK = 'internal_id cannot be blank if the bank is present'

--- a/app/models/partners/dexcom/auth_token.rb
+++ b/app/models/partners/dexcom/auth_token.rb
@@ -11,6 +11,8 @@ module Partners
       field :refresh_token, :string
 
       def self.instance
+        Jets.logger.warn 'This class is deprecated, use AuthToken instead'
+
         create if first.nil?
 
         first

--- a/app/services/finance/aib/service.rb
+++ b/app/services/finance/aib/service.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+module Finance
+  module Aib
+    class AuthError < StandardError; end
+
+    class Service
+      def get_transactions(from, to = nil)
+        to ||= from
+
+        authenticate unless @auth_token
+
+        response = request_transactions(from, to)
+
+        if response.unauthorized?
+          authenticate
+          response = request_transactions(from, to)
+        end
+
+        response['results']
+      rescue Finance::Aib::AuthError => e
+        Jets.logger.warn "Authentication error: #{e.message}"
+
+        publish_auth_error_metric
+
+        []
+      end
+
+      private
+
+      def request_transactions(from, to)
+        response = HTTParty.get(
+          api_endpoint,
+          headers: api_headers,
+          query: { from: from.strftime('%Y-%m-%d'), to: to.strftime('%Y-%m-%d') }
+        )
+      end
+
+      def api_endpoint
+        "https://api.#{ENV['TRUELAYER_BASE_URL']}/data/v1/accounts/#{ENV['TRUELAYER_AIB_ACCOUNT_ID']}/transactions"
+      end
+
+      def api_headers
+        { 'Authorization' => "Bearer #{@auth_token.access_token}" }
+      end
+
+      def authenticate
+        @auth_token = AuthToken.token_for(AuthToken::PROVIDER_AIB)
+
+        request_access_token if @auth_token.access_token.nil?
+        refresh_access_token if Time.at(@auth_token.expiration_time).past?
+
+        @auth_token
+      end
+
+      def request_access_token
+        if @auth_token.authorization_code.nil?
+          raise Finance::Aib::AuthError, "Authorization code not present"
+        end
+
+        response = HTTParty.post(
+          auth_endpoint,
+          headers: headers,
+          body: request_access_token_payload
+        )
+
+        if response.ok?
+          update_auth_token(response)
+        else
+          refresh_access_token
+        end
+      end
+
+      def auth_endpoint
+        "https://auth.#{ENV['TRUELAYER_BASE_URL']}/connect/token"
+      end
+
+      def headers
+        { 'Content-Type': 'application/x-www-form-urlencoded' }
+      end
+
+      def common_auth_payload
+        {
+          client_id: ENV['TRUELAYER_CLIENT_ID'],
+          client_secret: ENV['TRUELAYER_CLIENT_SECRET']
+        }
+      end
+
+      def request_access_token_payload
+        {
+          grant_type: 'authorization_code',
+          code: @auth_token.authorization_code,
+          redirect_uri: ENV['TRUELAYER_REDIRECT_URL']
+        }.merge!(common_auth_payload)
+      end
+
+      def refresh_access_token
+        response = HTTParty.post(
+          auth_endpoint,
+          headers: headers,
+          body: refresh_access_token_payload
+        )
+
+        if response.bad_request?
+          raise Finance::Aib::AuthError, "Error while refreshing auth token"
+        end
+
+        update_auth_token(response)
+      end
+
+      def refresh_access_token_payload
+        {
+          grant_type: 'refresh_token',
+          refresh_token: @auth_token.refresh_token
+        }.merge!(common_auth_payload)
+      end
+
+      def update_auth_token(response)
+        auth_token = AuthToken.token_for(AuthToken::PROVIDER_AIB)
+
+        auth_token.access_token = response['access_token']
+        auth_token.expiration_time = Time.now.to_i + response['expires_in'].to_i
+        auth_token.refresh_token = response['refresh_token']
+        auth_token.save!
+
+        @auth_token = auth_token
+      end
+
+      def publish_auth_error_metric
+        retry_metric = Metrics::BaseMetric.new
+        retry_metric.namespace = "#{Metrics::Namespaces::INFRASTRUCTURE}/#{Metrics::Namespaces::FINANCE}/AIB"
+        retry_metric.metric_name = 'Auth error'
+        retry_metric.unit = Metrics::Units::COUNT
+        retry_metric.value = 1
+        retry_metric.timestamp = DateTime.now
+        retry_metric.dimensions = []
+
+        PublishCloudwatchDataCommand.new(retry_metric).execute
+      end
+    end
+  end
+end

--- a/app/services/finance/aib/transaction_builder.rb
+++ b/app/services/finance/aib/transaction_builder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Finance
+  module Aib
+    class TransactionBuilder < ::Finance::BaseTransactionBuilder
+      private
+
+      def amount_in_cents
+        @transaction_information['amount'] * CENTS_PER_EURO
+      end
+
+      def bank
+        'AIB'
+      end
+
+      def internal_id
+        @transaction_information['transaction_id']
+      end
+
+      def transaction_datetime
+        DateTime.parse(@transaction_information['timestamp']).to_date
+      end
+
+      def description
+        @transaction_information['description']
+      end
+    end
+  end
+end

--- a/infrastructure/alarms.yml
+++ b/infrastructure/alarms.yml
@@ -122,3 +122,19 @@ Resources:
       TreatMissingData: notBreaching
       AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
       OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+
+  AIBAuthErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alexgascon-api_AIB-auth-error
+      AlarmDescription: Fires if there are errors when authenticating to retrieve AIB transactions data
+      EvaluationPeriods: 1
+      Namespace: Infrastructure/Finance/AIB
+      MetricName: Auth error
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Statistic: Sum
+      Period: 300
+      Threshold: 1
+      TreatMissingData: notBreaching
+      AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']

--- a/spec/factories/auth_tokens.rb
+++ b/spec/factories/auth_tokens.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :aib_token, class: AuthToken do
+    access_token        { 'defaultFactoryAccessToken' }
+    authorization_code  { '122345678' }
+    expiration_time     { '14974924021' }
+    refresh_token       { 'defaultFactoryRefreshToken' }
+    provider            { :aib }
+  end
+end

--- a/spec/fixtures/finance/aib/transaction.json
+++ b/spec/fixtures/finance/aib/transaction.json
@@ -1,0 +1,13 @@
+{
+    "timestamp":"2020-08-10T23:00:00Z",
+    "description":"VDP-AMZNMktplace",
+    "transaction_type":"DEBIT",
+    "transaction_category":"DEBIT",
+    "transaction_classification":[],
+    "amount":-26.37,
+    "currency":"EUR",
+    "transaction_id":"7ee551d422dfd72ebe2b144396bb280c",
+    "meta": {
+        "transaction_type":"Debit"
+    }
+}

--- a/spec/fixtures/finance/truelayer/aib_transactions.json
+++ b/spec/fixtures/finance/truelayer/aib_transactions.json
@@ -1,0 +1,41 @@
+[
+    {
+        "timestamp":"2020-08-10T23:00:00Z",
+        "description":"VDP-AMZNMktplace",
+        "transaction_type":"DEBIT",
+        "transaction_category":"DEBIT",
+        "transaction_classification":[],
+        "amount":-26.37,
+        "currency":"EUR",
+        "transaction_id":"7ee551d422dfd72ebe2b144396bb280c",
+        "meta": {
+            "transaction_type":"Debit"
+        }
+    },
+    {
+        "timestamp":"2020-08-10T23:00:00Z",
+        "description":"VDP-DIGIWEB-EUR",
+        "transaction_type":"DEBIT",
+        "transaction_category":"DEBIT",
+        "transaction_classification":[],
+        "amount":-39.95,
+        "currency":"EUR",
+        "transaction_id":"5041362cef487681d06e369d6c1d4890",
+        "meta":{
+            "transaction_type":"Debit"
+        }
+    },
+    {
+        "timestamp":"2020-08-10T23:00:00Z",
+        "description":"VDP-MIP*3IRELAND T",
+        "transaction_type":"DEBIT",
+        "transaction_category":"DEBIT",
+        "transaction_classification":[],
+        "amount":-15.0,
+        "currency":"EUR",
+        "transaction_id":"47f3bec11b42052013ffbf83f567ae75",
+        "meta":{
+            "transaction_type":"Debit"
+        }
+    }
+]

--- a/spec/fixtures/finance/truelayer/aib_transactions_response.json
+++ b/spec/fixtures/finance/truelayer/aib_transactions_response.json
@@ -1,0 +1,44 @@
+{
+    "results": [
+        {
+            "timestamp":"2020-08-10T23:00:00Z",
+            "description":"VDP-AMZNMktplace",
+            "transaction_type":"DEBIT",
+            "transaction_category":"DEBIT",
+            "transaction_classification":[],
+            "amount":-26.37,
+            "currency":"EUR",
+            "transaction_id":"7ee551d422dfd72ebe2b144396bb280c",
+            "meta": {
+                "transaction_type":"Debit"
+            }
+        },
+        {
+            "timestamp":"2020-08-10T23:00:00Z",
+            "description":"VDP-DIGIWEB-EUR",
+            "transaction_type":"DEBIT",
+            "transaction_category":"DEBIT",
+            "transaction_classification":[],
+            "amount":-39.95,
+            "currency":"EUR",
+            "transaction_id":"5041362cef487681d06e369d6c1d4890",
+            "meta":{
+                "transaction_type":"Debit"
+            }
+        },
+        {
+            "timestamp":"2020-08-10T23:00:00Z",
+            "description":"VDP-MIP*3IRELAND T",
+            "transaction_type":"DEBIT",
+            "transaction_category":"DEBIT",
+            "transaction_classification":[],
+            "amount":-15.0,
+            "currency":"EUR",
+            "transaction_id":"47f3bec11b42052013ffbf83f567ae75",
+            "meta":{
+                "transaction_type":"Debit"
+            }
+        }
+    ],
+    "status":"Succeeded"
+}

--- a/spec/fixtures/finance/truelayer/no_transactions.json
+++ b/spec/fixtures/finance/truelayer/no_transactions.json
@@ -1,0 +1,4 @@
+{
+    "results": [],
+    "status": "Succeeded"
+}

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe AuthToken do
+  describe '.token_for' do
+    let(:provider) { AuthToken::PROVIDER_AIB }
+
+    context 'if the token has not been created yet' do
+      before do
+        described_class.delete_table
+        described_class.create_table
+      end
+
+      it 'creates a new token' do
+        expect { described_class.token_for(provider).save }.to change { described_class.count }.by(1)
+      end
+    end
+
+    context 'if a token already exists' do
+      before { FactoryBot.create(:aib_token) }
+
+      it 'always returns the same instance' do
+        expect(described_class.token_for(provider)).to eq(described_class.token_for(provider))
+      end
+
+      it 'does not create new tokens' do
+        expect { described_class.token_for(provider).save }.not_to(change { described_class.count })
+      end
+    end
+
+    context 'when the provider is not valid' do
+      it 'raises an exception' do
+        expect { described_class.token_for(:some_provider) }.to raise_error(InvalidTokenProvider)
+      end
+    end
+  end
+
+  describe '.new' do
+    it 'is marked as private' do
+      skip 'Dynamoid calls .new when doing first, last and other methods; look for a workaround'
+      expect { described_class.new }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/services/finance/aib/service_spec.rb
+++ b/spec/services/finance/aib/service_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::Aib::Service do
+  let(:truelayer_credentials) do
+    {
+      TRUELAYER_AIB_ACCOUNT_ID: '123456789009876543212',
+      TRUELAYER_BASE_URL: 'fake-truelayer.com',
+      TRUELAYER_CLIENT_ID: 'myclientid-1234ab',
+      TRUELAYER_CLIENT_SECRET: 'e9f9a53e-9db9-4707-aaa7-c9a117b4d12c',
+      TRUELAYER_REDIRECT_URL: 'https://redirect.fake-truelayer.com/redirect'
+    }
+  end
+
+  let(:content_type_json) { { 'Content-Type'=> 'application/json' } }
+
+  before do
+    travel_to Time.new(2020, 8, 1, 12, 34, 56)
+    stub_command PublishCloudwatchDataCommand
+  end
+
+  around { |example| with_modified_env(truelayer_credentials) { example.run } }
+
+  after do
+    travel_back
+  end
+
+  subject { described_class.new.get_transactions(Date.yesterday, Date.today) }
+
+  describe 'get_transactions' do
+    let(:get_transactions_request) do
+      stub_request(:get, 'https://api.fake-truelayer.com/data/v1/accounts/123456789009876543212/transactions')
+      .with(
+        headers: { 'Authorization' => 'Bearer defaultFactoryAccessToken' },
+        query: { from: '2020-07-31', to: '2020-08-01'}
+      )
+    end
+    let(:get_transactions_response) { load_json_fixture 'finance/truelayer/aib_transactions_response' }
+
+
+    context 'when a valid token exists' do
+      before do
+        FactoryBot.create(:aib_token, expiration_time: Time.now.to_i + 200)
+        get_transactions_request.to_return(status: 200, body: get_transactions_response.to_json, headers: content_type_json)
+      end
+
+      it 'retrieves the bank movements' do
+        expected_movements = load_json_fixture('finance/truelayer/aib_transactions')
+        expect(subject).to eq expected_movements
+      end
+
+      context 'when there are no bank movements' do
+        let(:get_transactions_response) { load_json_fixture 'finance/truelayer/no_transactions' }
+
+        it 'returns an empty array' do
+          expect(subject).to eq []
+        end
+      end
+    end
+
+    context 'when the access token has expired' do
+      before do
+        FactoryBot.create(:aib_token, expiration_time: Time.now.to_i - 200)
+        get_transactions_request.to_return(status: 401)
+      end
+
+      let(:refresh_token_payload) do
+        {
+          client_id: 'myclientid-1234ab', client_secret: 'e9f9a53e-9db9-4707-aaa7-c9a117b4d12c',
+          grant_type: 'refresh_token', refresh_token: 'defaultFactoryRefreshToken'
+        }
+      end
+      let(:refresh_token_ok_response) do
+        {
+          access_token: 'refreshedSuperLongAndRandomAccessTokenReturnedByTruelayer', expire_in: '60',
+          refresh_token: 'my-second-refresh-token', token_type: 'Bearer'
+        }
+      end
+      let(:refresh_token_request) do
+        stub_request(:post, 'https://auth.fake-truelayer.com/connect/token')
+        .with(
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: refresh_token_payload
+        )
+      end
+      let(:get_transactions_request_with_refreshed_token) do
+        stub_request(:get, 'https://api.fake-truelayer.com/data/v1/accounts/123456789009876543212/transactions')
+        .with(
+          headers: { 'Authorization' => 'Bearer refreshedSuperLongAndRandomAccessTokenReturnedByTruelayer' },
+          query: { from: '2020-07-31', to: '2020-08-01'}
+        )
+      end
+
+      context 'when the token renewal is successful' do
+        before do
+          refresh_token_request.to_return(status: 200, body: refresh_token_ok_response.to_json, headers: content_type_json)
+          get_transactions_request_with_refreshed_token.to_return(status: 200, body: get_transactions_response.to_json, headers: content_type_json)
+        end
+
+        it 'refreshes the token' do
+          subject
+
+          expect(refresh_token_request).to have_been_requested
+        end
+
+        it 'retries the operation' do
+          subject
+
+          expect(get_transactions_request_with_refreshed_token).to have_been_requested
+        end
+      end
+
+      context 'when refreshing the token fails' do
+        before do
+          refresh_token_request.to_return(status: 400)
+        end
+
+        it 'emits an error metric' do
+          auth_error_metric = Metrics::BaseMetric.new
+          auth_error_metric.namespace = "Infrastructure/Finance/AIB"
+          auth_error_metric.metric_name = 'Auth error'
+          auth_error_metric.unit = 'Count'
+          auth_error_metric.value = 1
+          auth_error_metric.timestamp = Time.new(2020, 8, 1, 12, 34, 56)
+          auth_error_metric.dimensions = []
+
+          expect(PublishCloudwatchDataCommand).to receive(:new).with(auth_error_metric)
+          subject
+        end
+
+        it 'returns an empty array' do
+          expect(subject).to eq []
+        end
+      end
+    end
+  end
+end

--- a/spec/services/finance/aib/transaction_builder_spec.rb
+++ b/spec/services/finance/aib/transaction_builder_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::Aib::TransactionBuilder do
+  let(:transaction_information) { load_json_fixture 'finance/aib/transaction' }
+
+  describe '#build' do
+    subject(:bank_transaction) { described_class.new(transaction_information).build }
+
+    it 'sets the amount_in_cents' do
+      expect(bank_transaction.amount_in_cents).to eq -2637
+    end
+
+    it 'sets the bank' do
+      expect(bank_transaction.bank).to eq 'AIB'
+    end
+
+    it 'sets the datetime' do
+      expect(bank_transaction.datetime).to eq DateTime.parse('2020-08-10')
+    end
+
+    it 'sets the description' do
+      expect(bank_transaction.description).to eq 'VDP-AMZNMktplace'
+    end
+
+    it 'sets the internal_id' do
+      expect(bank_transaction.internal_id).to eq '7ee551d422dfd72ebe2b144396bb280c'
+    end
+
+    it 'sets year_month' do
+      expect(bank_transaction.year_month).to eq '2020-08'
+    end
+
+    it 'sets day' do
+      expect(bank_transaction.day).to eq '10'
+    end
+  end
+end


### PR DESCRIPTION
Closes #39

### Description
Adding AIB to the list of banks whose transactions we retrieve

In order to do so, we'll be using [TrueLayer](https://docs.truelayer.com) instead of AIB API directly, as it offers better documentation and the registration, activation and usage of the API is easier. We'll be following the usual structure for bank integrations: having a main service for the API interaction, and a `TransactionBuilder` to create the bank transaction from the retrieved information

We have created a new class, AuthToken, that will be used to store the authentication token information. It is basically the same logic that we had on `Partners::Dexcom::AuthToken`, but adapted to work with multiple providers

Because of the difference in authentication in this case (if the stored token is not valid and cannot be updated we cannot get one without user interaction) we will be adding an additional CloudWatch Alarm to monitor Auth errors in the API.