### PR TITLE
Fixing timezones issue on AIB service

### DIFF
--- a/app/services/finance/aib/service.rb
+++ b/app/services/finance/aib/service.rb
@@ -34,13 +34,21 @@ module Finance
       private
 
       def request_transactions(from, to)
-        # TrueLayer considers the end of the range to not to be included
-        # so to get its movements we need to ask for the transactions up
-        # to the following day
-        response = HTTParty.get(
+        # AIB uses Irish Standard Time (IST) for its transactions, so in UTC it's
+        # 1 hour less. This means that a transaction registered at 00:00 IST
+        # will be returned by TrueLayer as belonging to the previous day.
+        #
+        # To avoid this problem, we'll make the conversion before sending
+        # the request to TrueLayer
+        #
+        # More context: https://github.com/AlexGascon/alexgascon-api/issues/43#issuecomment-678669868
+        from = from.to_time.in_time_zone('Europe/Dublin').beginning_of_day.utc
+        to = to.to_time.in_time_zone('Europe/Dublin').end_of_day.utc
+
+        HTTParty.get(
           api_endpoint,
           headers: api_headers,
-          query: { from: from.strftime('%Y-%m-%d'), to: (to + 1.day).strftime('%Y-%m-%d') }
+          query: { from: from.iso8601, to: to.iso8601 }
         )
       end
 

--- a/app/services/finance/aib/transaction_builder.rb
+++ b/app/services/finance/aib/transaction_builder.rb
@@ -18,7 +18,7 @@ module Finance
       end
 
       def transaction_datetime
-        DateTime.parse(@transaction_information['timestamp']).to_date
+        DateTime.parse(@transaction_information['timestamp']).in_time_zone('Europe/Dublin').to_date
       end
 
       def description

--- a/spec/services/finance/aib/service_spec.rb
+++ b/spec/services/finance/aib/service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Finance::Aib::Service do
       stub_request(:get, 'https://api.fake-truelayer.com/data/v1/accounts/123456789009876543212/transactions')
       .with(
         headers: { 'Authorization' => 'Bearer defaultFactoryAccessToken' },
-        query: { from: '2020-07-31', to: '2020-08-02'}
+        query: { from: '2020-07-30T23:00:00Z', to: '2020-08-01T22:59:59Z' }
       )
     end
     let(:get_transactions_response) { load_json_fixture 'finance/truelayer/aib_transactions_response' }
@@ -99,7 +99,7 @@ RSpec.describe Finance::Aib::Service do
         stub_request(:get, 'https://api.fake-truelayer.com/data/v1/accounts/123456789009876543212/transactions')
         .with(
           headers: { 'Authorization' => 'Bearer refreshedSuperLongAndRandomAccessTokenReturnedByTruelayer' },
-          query: { from: '2020-07-31', to: '2020-08-02'}
+          query: { from: '2020-07-30T23:00:00Z', to: '2020-08-01T22:59:59Z' }
         )
       end
 

--- a/spec/services/finance/aib/transaction_builder_spec.rb
+++ b/spec/services/finance/aib/transaction_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Finance::Aib::TransactionBuilder do
     end
 
     it 'sets the datetime' do
-      expect(bank_transaction.datetime).to eq DateTime.parse('2020-08-10')
+      expect(bank_transaction.datetime).to eq DateTime.parse('2020-08-11')
     end
 
     it 'sets the description' do
@@ -31,7 +31,7 @@ RSpec.describe Finance::Aib::TransactionBuilder do
     end
 
     it 'sets day' do
-      expect(bank_transaction.day).to eq '10'
+      expect(bank_transaction.day).to eq '11'
     end
   end
 end


### PR DESCRIPTION
Closes #43

AIB uses Irish Standard Time (IST) for its transactions, so in UTC it's
1 hour less. This means that a transaction registered at 00:00 IST
will be returned by TrueLayer as belonging to the previous day.

To avoid this problem, we'll make the conversion before sending
the request to TrueLayer, and also when building the BankTransaction
from their response

More context: https://github.com/AlexGascon/alexgascon-api/issues/43#issuecomment-678669868