### PR TITLE
Improving observability on bank services

### DIFF
--- a/app/services/finance/bankia/service.rb
+++ b/app/services/finance/bankia/service.rb
@@ -160,13 +160,9 @@ module Finance
       end
 
       def publish_metrics
-        retry_metric = Metrics::BaseMetric.new
-        retry_metric.namespace = "#{Metrics::Namespaces::INFRASTRUCTURE}/#{Metrics::Namespaces::FINANCE}/Fintonic"
+        retry_metric = base_bankia_metric
         retry_metric.metric_name = 'get_transactions retries'
-        retry_metric.unit = Metrics::Units::COUNT
         retry_metric.value = @retries
-        retry_metric.timestamp = DateTime.now
-        retry_metric.dimensions = []
 
         request_error_metric = base_bankia_metric
         request_error_metric.metric_name = 'Request transactions error'

--- a/app/services/finance/bankia/service.rb
+++ b/app/services/finance/bankia/service.rb
@@ -9,37 +9,38 @@ module Finance
 
       def initialize
         @retries = 0
+        @request_error = false
+        @exception = false
       end
 
       def get_transactions(from, to = nil)
         to ||= from
 
-        authenticate unless @auth_token
+        authenticate
 
         response = request_transactions(from, to)
 
-        if response.unauthorized?
-          authenticate
-          response = request_transactions(from, to)
+        unless response.ok?
+          return handle_error(response, :request)
         end
 
-        # Note: when there are no movements for the specified date range, Fintonic
-        # returns movements anyway. To mimic this behavior, we'll return a
-        # response with movements on dates differents to the specified
+        # Note: when there are no transactions for the specified date range, Fintonic
+        # returns transactions anyway. To avoid propagating them, we'll make sure
+        # that we are selecting transactions in the specified range
         response
           .yield_self { |r| JSON.parse(r .body) }
           .dig('resultList')
           .select { |transaction| correct_date_range?(transaction, from, to) }
       rescue EOFError
         Jets.logger.warn "Error while retrieving bank transactions, retrying... Retry #: #{@retries}"
-
         @retries += 1
         retry unless @retries > MAX_RETRIES
 
-        Jets.logger.error('No more retries left, aborting')
-        []
+        handle_error({}, :no_more_retries)
+      rescue StandardError => e
+        handle_error(e, :exception)
       ensure
-        publish_retry_metric
+        publish_metrics
       end
 
       private
@@ -125,7 +126,40 @@ module Finance
         @device_uuid ||= ENV['FINTONIC_DEVICE_UUID']
       end
 
-      def publish_retry_metric
+      def handle_error(additional_data, error_type)
+        case error_type
+        when :no_more_retries
+          Jets.logger.error('No more retries left, aborting')
+          @exception = true
+        when :request
+          handle_request_error(additional_data)
+        when :exception
+          handle_exception(additional_data)
+        end
+
+        []
+      end
+
+      def handle_request_error(response)
+        Jets.logger.warn "Error in #{self.class}: Non-200 status code received: #{response.code}"
+        @request_error = true
+      end
+
+      def handle_exception(exception)
+        @exception = true
+      end
+
+      def base_bankia_metric
+        metric = Metrics::BaseMetric.new
+        metric.namespace = "#{Metrics::Namespaces::INFRASTRUCTURE}/#{Metrics::Namespaces::FINANCE}"
+        metric.unit = Metrics::Units::COUNT
+        metric.timestamp = DateTime.now
+        metric.dimensions = [{ name: 'Bank', value: 'Bankia' }]
+
+        metric
+      end
+
+      def publish_metrics
         retry_metric = Metrics::BaseMetric.new
         retry_metric.namespace = "#{Metrics::Namespaces::INFRASTRUCTURE}/#{Metrics::Namespaces::FINANCE}/Fintonic"
         retry_metric.metric_name = 'get_transactions retries'
@@ -134,7 +168,17 @@ module Finance
         retry_metric.timestamp = DateTime.now
         retry_metric.dimensions = []
 
+        request_error_metric = base_bankia_metric
+        request_error_metric.metric_name = 'Request transactions error'
+        request_error_metric.value = @request_error ? 1 : 0
+
+        exception_metric = base_bankia_metric
+        exception_metric.metric_name = 'Exception'
+        exception_metric.value = @exception ? 1 : 0
+
         PublishCloudwatchDataCommand.new(retry_metric).execute
+        PublishCloudwatchDataCommand.new(request_error_metric).execute
+        PublishCloudwatchDataCommand.new(exception_metric).execute
       end
     end
   end

--- a/app/services/finance/openbank/service.rb
+++ b/app/services/finance/openbank/service.rb
@@ -135,15 +135,9 @@ module Finance
       end
 
       def publish_metrics
-        # Namespace and Dimensions are different for backwards compatibility
-        # This metric was created first and we didn't use any convention then 
-        retry_metric = Metrics::BaseMetric.new
-        retry_metric.namespace = "#{Metrics::Namespaces::INFRASTRUCTURE}/#{Metrics::Namespaces::FINANCE}/Openbank"
+        retry_metric = base_openbank_metric
         retry_metric.metric_name = 'get_transactions retries'
-        retry_metric.unit = Metrics::Units::COUNT
         retry_metric.value = @retries
-        retry_metric.timestamp = DateTime.now
-        retry_metric.dimensions = []
 
         request_error_metric = base_openbank_metric
         request_error_metric.metric_name = 'Request transactions error'

--- a/app/services/finance/openbank/service.rb
+++ b/app/services/finance/openbank/service.rb
@@ -10,37 +10,32 @@ module Finance
 
       def initialize
         @retries = 0
+        @request_error = false
+        @exception = false
       end
 
       def get_transactions(from, to = nil)
         to ||= from
 
-        authenticate unless @auth_token
+        authenticate
 
         response = request_transactions(from, to)
 
-        if response.unauthorized?
-          authenticate
-          response = request_transactions(from, to)
-        end
-
-        if response.not_found?
-          Jets.logger.info "No new bank transactions on the range from #{from} to #{to}"
-
-          return []
+        unless response.ok?
+          return handle_error(response, :request)
         end
 
         response['movimientos']
       rescue EOFError
         Jets.logger.warn "Error while retrieving bank transactions, retrying... Retry #: #{@retries}"
-
         @retries += 1
         retry unless @retries > MAX_RETRIES
 
-        Jets.logger.error('No more retries left, aborting')
-        []
+        handle_error({}, :no_more_retries)
+      rescue StandardError => e
+        handle_error(e, :exception)
       ensure
-        publish_retry_metric
+        publish_metrics
       end
 
       private
@@ -101,7 +96,47 @@ module Finance
         }
       end
 
-      def publish_retry_metric
+      def handle_error(additional_data, error_type)
+        case error_type
+        when :no_more_retries
+          Jets.logger.error('No more retries left, aborting')
+          @exception = true
+        when :request
+          handle_request_error(additional_data)
+        when :exception
+          handle_exception(additional_data)
+        end
+
+        []
+      end
+
+      def handle_exception(exception)
+        Jets.logger.warn "Error in #{self.class}: #{exception.message}"
+        @exception = true
+      end
+
+      def handle_request_error(response)
+        if response.not_found?
+          Jets.logger.info "No new bank transactions"
+        else
+          Jets.logger.warn "Error in #{self.class}: Non-200 status code received: #{response.code}"
+          @request_error = true
+        end
+      end
+
+      def base_openbank_metric
+        metric = Metrics::BaseMetric.new
+        metric.namespace = "#{Metrics::Namespaces::INFRASTRUCTURE}/#{Metrics::Namespaces::FINANCE}"
+        metric.unit = Metrics::Units::COUNT
+        metric.timestamp = DateTime.now
+        metric.dimensions = [{ name: 'Bank', value: 'Openbank' }]
+
+        metric
+      end
+
+      def publish_metrics
+        # Namespace and Dimensions are different for backwards compatibility
+        # This metric was created first and we didn't use any convention then 
         retry_metric = Metrics::BaseMetric.new
         retry_metric.namespace = "#{Metrics::Namespaces::INFRASTRUCTURE}/#{Metrics::Namespaces::FINANCE}/Openbank"
         retry_metric.metric_name = 'get_transactions retries'
@@ -110,7 +145,17 @@ module Finance
         retry_metric.timestamp = DateTime.now
         retry_metric.dimensions = []
 
+        request_error_metric = base_openbank_metric
+        request_error_metric.metric_name = 'Request transactions error'
+        request_error_metric.value = @request_error ? 1 : 0
+
+        exception_metric = base_openbank_metric
+        exception_metric.metric_name = 'Exception'
+        exception_metric.value = @exception ? 1 : 0
+
         PublishCloudwatchDataCommand.new(retry_metric).execute
+        PublishCloudwatchDataCommand.new(request_error_metric).execute
+        PublishCloudwatchDataCommand.new(exception_metric).execute
       end
     end
   end

--- a/infrastructure/Alarms-Infrastructure.yml
+++ b/infrastructure/Alarms-Infrastructure.yml
@@ -129,12 +129,138 @@ Resources:
       AlarmName: alexgascon-api_AIB-auth-error
       AlarmDescription: Fires if there are errors when authenticating to retrieve AIB transactions data
       EvaluationPeriods: 1
-      Namespace: Infrastructure/Finance/AIB
+      Namespace: Infrastructure/Finance
       MetricName: Auth error
+      Dimensions:
+        - Name: Bank
+          Value: AIB
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Statistic: Sum
       Period: 300
       Threshold: 1
       TreatMissingData: ignore
+      AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+
+  AIBErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alexgascon-api_AIB-Error
+      AlarmDescription: Fires if there are errors when retrieving AIB transactions data
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 1
+      TreatMissingData: ignore
+      Metrics:
+        - Label: AIB errors
+          Id: e1
+          Expression: SUM([m1, m2])
+          ReturnData: true
+        - Id: m1
+          MetricStat:
+            Metric:
+              Namespace: Infrastructure/Finance
+              MetricName: Exception
+              Dimensions:
+                - Name: Bank
+                  Value: AIB
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Namespace: Infrastructure/Finance
+              MetricName: Exception
+              Dimensions:
+                - Name: Bank
+                  Value: AIB
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+
+  BankiaErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alexgascon-api_Bankia-Error
+      AlarmDescription: Fires if there are errors when retrieving Bankia transactions data
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 1
+      TreatMissingData: ignore
+      Metrics:
+        - Label: Bankia errors
+          Id: e1
+          Expression: SUM([m1, m2])
+          ReturnData: true
+        - Id: m1
+          MetricStat:
+            Metric:
+              Namespace: Infrastructure/Finance
+              MetricName: Exception
+              Dimensions:
+                - Name: Bank
+                  Value: Bankia
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Namespace: Infrastructure/Finance
+              MetricName: Exception
+              Dimensions:
+                - Name: Bank
+                  Value: Bankia
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+
+  OpenbankErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alexgascon-api_Openbank-Error
+      AlarmDescription: Fires if there are errors when retrieving Openbank transactions data
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 1
+      TreatMissingData: ignore
+      Metrics:
+        - Label: Openbank errors
+          Id: e1
+          Expression: SUM([m1, m2])
+          ReturnData: true
+        - Id: m1
+          MetricStat:
+            Metric:
+              Namespace: Infrastructure/Finance
+              MetricName: Exception
+              Dimensions:
+                - Name: Bank
+                  Value: Openbank
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Namespace: Infrastructure/Finance
+              MetricName: Exception
+              Dimensions:
+                - Name: Bank
+                  Value: Openbank
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
       AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
       OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']

--- a/spec/services/finance/bankia/service_spec.rb
+++ b/spec/services/finance/bankia/service_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe Finance::Bankia::Service do
 
   let(:retries_metric) do
     retry_metric = Metrics::BaseMetric.new
-    retry_metric.namespace = "Infrastructure/Finance/Fintonic"
+    retry_metric.namespace = 'Infrastructure/Finance'
     retry_metric.metric_name = 'get_transactions retries'
     retry_metric.unit = 'Count'
     retry_metric.value = expected_retries
     retry_metric.timestamp = Time.new(2020, 5, 3, 12, 34, 56)
-    retry_metric.dimensions = []
+    retry_metric.dimensions = [{ name: 'Bank', value: 'Bankia' }]
 
     retry_metric
   end

--- a/spec/services/finance/openbank/service_spec.rb
+++ b/spec/services/finance/openbank/service_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe Finance::Openbank::Service do
 
   let(:retries_metric) do
     retry_metric = Metrics::BaseMetric.new
-    retry_metric.namespace = "Infrastructure/Finance/Openbank"
+    retry_metric.namespace = "Infrastructure/Finance"
     retry_metric.metric_name = 'get_transactions retries'
     retry_metric.unit = 'Count'
     retry_metric.value = expected_retries
     retry_metric.timestamp = Time.new(2020, 5, 3, 12, 34, 56)
-    retry_metric.dimensions = []
+    retry_metric.dimensions = [{ name: 'Bank', value: 'Openbank' }]
 
     retry_metric
   end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -7,3 +7,9 @@ RSpec.shared_examples 'retry metric' do |retries|
     subject
   end
 end
+
+RSpec.shared_examples 'returns an empty array' do
+  it 'returns an empty array' do
+    expect(subject).to eq []
+  end
+end


### PR DESCRIPTION
## Description
Several changes targetting to improve the observability on the services that communicate with AIB, Bankia and Openbank:

### Additional metrics 
Adding additional metrics to the different bank services to allow for better monitoring. The metrics added to all the bank services are:
- **Request error**: Representing when we don't get a 200 HTTP response from the bank API
- **Exception**: Representing when an exception is raised during the transaction retrieval

### Alarms
Created CW Alarms for each of these metrics, in order to get alerted immediately whenever something goes wrong

### Unifying metrics structure
Changed from having a different Namespace for each bank to unify the namespace and metric name across banks, and just setting a dimension to represent the bank