### PR TITLE
Adding monthly expenses to the Telegram message

### DIFF
--- a/app/jobs/finance/notify_yesterday_transactions_job.rb
+++ b/app/jobs/finance/notify_yesterday_transactions_job.rb
@@ -21,6 +21,15 @@ module Finance
           .to_a
     end
 
+    def monthly_transactions
+      yesterday_year_month = Date.yesterday.strftime('%Y-%m')
+
+      @monthly_transactions ||=
+        Finance::BankTransaction
+          .where('year_month': yesterday_year_month)
+          .to_a
+    end
+
     def telegram_message
       <<~MSG
       #{Emojis::FLYING_MONEY} #{yesterday_transactions.size} expenses yesterday #{Emojis::FLYING_MONEY}
@@ -28,6 +37,7 @@ module Finance
       #{yesterday_transactions.map { |t| format_transaction(t) }.join("\n\n")}
 
       Total: #{yesterday_transactions.map(&:amount).sum}€
+      Month to date: #{monthly_transactions.map(&:amount).sum}€
       MSG
     end
 


### PR DESCRIPTION
## Description
Adding an extra line to the Telegram message that notifies of money spending to also inform of the total expense month to date. This will simplify the way of tracking expenses on a specific month

## How?
We will follow the same approach that we use to get yesterday's transaction, but without specifying any day on the query. As the index uses `year_month` as the hash key, we can do that and the query will still be efficient. 