### PR TITLE
PoC for DynamoDB events

### DIFF
--- a/app/jobs/finance/bank_transaction_created_job.rb
+++ b/app/jobs/finance/bank_transaction_created_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Finance
+  class BankTransactionCreatedJob < ::ApplicationJob
+
+    dynamodb_event 'alexgascon-api_production_banktransactions'
+    def run
+      Jets.logger.info "DynamoDB event: #{event}"
+
+      SendTelegramMessageCommand.new(bank_transaction.to_s).execute
+    end
+
+    private
+
+    def bank_transaction
+      @bank_transaction ||= get_bank_transaction
+    end
+
+    def get_bank_transaction
+      bank_transaction_data = event['Records'].first['dynamodb']
+      bank_transaction_id = bank_transaction_data.dig('keys', 'id', 'S')
+
+      Finance::BankTransaction.find(bank_transaction_id)
+    end
+  end
+end

--- a/app/models/finance/bank_transaction.rb
+++ b/app/models/finance/bank_transaction.rb
@@ -46,6 +46,10 @@ module Finance
       errors.add(:internal_id, ERROR_INTERNAL_ID_BLANK) if internal_id.blank?
     end
 
+    def to_s
+      "Finance::BankTransaction(description: #{description}, amount: #{amount}, bank: #{bank}, datetime: #{datetime})"
+    end
+
     private
 
     def bank_is_valid?

--- a/lib/tasks/temp/20201023_enable_dynamodb_streams_on_bank_transactions.rake
+++ b/lib/tasks/temp/20201023_enable_dynamodb_streams_on_bank_transactions.rake
@@ -1,0 +1,18 @@
+namespace :temp do
+  desc 'Enable DynamoDB streams on the Bank Transactions table'
+  task enable_dynamodb_streams_on_banktransaction: :environment do
+    dynamodb = Aws::DynamoDB::Client.new
+
+    Jets.logger.info 'Updating the Expenses table...'
+    dynamodb.update_table(
+      table_name: 'alexgascon-api_production_banktransactions',
+      stream_specification: {
+        stream_enabled: true,
+        stream_view_type: 'NEW_IMAGE'
+      }
+    )
+
+    Jets.logger.info 'Update operation started!'
+    Jets.logger.info 'This is an async operation, so results will not be immediate'
+  end
+end


### PR DESCRIPTION
## Description
Creating a job that will execute each time that a job transaction is 
created. For the moment this job will only send a Telegram message with 
information about the bank transaction. We want to use this as a proof of
concept of how DynamoDB events work, and if they would be suitable for the
use case we are planning on #40

Additionally, creating a rake task to enable DynamoDB streams on the
BankTransactions table. This is required for DynamoDB events to work