### PR TITLE
Migrating Meals model to SQL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,12 @@ jobs:
                 AWS_SECRET: 'fakeSecretKey'
             - image: amazon/dynamodb-local
               command: "-jar DynamoDBLocal.jar -inMemory -port 6000"
+            - image: postgres
+              environment:
+                POSTGRES_PASSWORD: 'test'
+                POSTGRES_USER: 'test'
+              ports:
+                - "5433"
     "ruby-26":
         <<: *common
         docker:
@@ -47,6 +53,12 @@ jobs:
                 AWS_SECRET: 'fakeSecretKey'
             - image: amazon/dynamodb-local
               command: "-jar DynamoDBLocal.jar -inMemory -port 6000"
+            - image: postgres
+              environment:
+                POSTGRES_PASSWORD: 'test'
+                POSTGRES_USER: 'test'
+              ports:
+                - "5433"
     "ruby-27":
         <<: *common
         docker:
@@ -56,6 +68,12 @@ jobs:
                 AWS_SECRET: 'fakeSecretKey'
             - image: amazon/dynamodb-local
               command: "-jar DynamoDBLocal.jar -inMemory -port 6000"
+            - image: postgres
+              environment:
+                POSTGRES_PASSWORD: 'test'
+                POSTGRES_USER: 'test'
+              ports:
+                - "5433"
 workflows:
   version: 2.1
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,6 @@ jobs:
               environment:
                 POSTGRES_PASSWORD: 'test'
                 POSTGRES_USER: 'test'
-              ports:
-                - "5433"
     "ruby-26":
         <<: *common
         docker:
@@ -57,8 +55,6 @@ jobs:
               environment:
                 POSTGRES_PASSWORD: 'test'
                 POSTGRES_USER: 'test'
-              ports:
-                - "5433"
     "ruby-27":
         <<: *common
         docker:
@@ -72,8 +68,6 @@ jobs:
               environment:
                 POSTGRES_PASSWORD: 'test'
                 POSTGRES_USER: 'test'
-              ports:
-                - "5433"
 workflows:
   version: 2.1
   build:

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'jets'
 
 gem 'airrecord'
+gem 'annotate'
 gem 'aws-sdk-cloudwatch'
 gem 'aws-sdk-s3'
 gem 'climate_control'
@@ -13,6 +14,7 @@ gem 'httparty'
 # Min version forced by Lambda https://github.com/tongueroo/jets/pull/470
 gem 'json', '>= 2.3.1'
 gem 'parallel'
+gem 'pg'
 gem 'telegram-bot-ruby'
 gem 'ynab'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,9 @@ GEM
     airrecord (1.0.5)
       faraday (>= 0.10, < 2.0)
       net-http-persistent (>= 2.9)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
@@ -221,6 +224,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.3)
       ast (~> 2.4.0)
+    pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -309,6 +313,7 @@ PLATFORMS
 
 DEPENDENCIES
   airrecord
+  annotate
   awesome_print
   aws-sdk-cloudwatch
   aws-sdk-s3
@@ -322,6 +327,7 @@ DEPENDENCIES
   json (>= 2.3.1)
   launchy
   parallel
+  pg
   pry
   pry-byebug
   pry-stack_explorer

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/health.rb
+++ b/app/models/health.rb
@@ -1,0 +1,5 @@
+module Health
+  def self.table_name_prefix
+    'health_'
+  end
+end

--- a/app/models/health/meal.rb
+++ b/app/models/health/meal.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: health_meals
+#
+#  id                     :bigint           not null, primary key
+#  carbohydrates_portions :float
+#  date                   :datetime
+#  food                   :text
+#  meal_type              :text
+#  notes                  :text
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
 module Health
-  class Meal
-    include Dynamoid::Document
-
-    field :carbohydrates_portions, :number
-    field :date, :date
-    field :food, :string
-    field :meal_type, :string
-    field :notes, :string
-
-    validates_presence_of :food
-    validates_presence_of :meal_type
+  class Meal < ::ApplicationRecord
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,3 +12,9 @@ development:
 test:
   <<: *common
   database: alexgascon-api_test
+production:
+  <<: *common
+  host: kandula.db.elephantsql.com
+  database: <%= ENV['POSTGRES_DB'] %>
+  username: <%= ENV['POSTGRES_USERNAME'] %>
+  password: <%= ENV['POSTGRES_PASSWORD'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ common: &common
   username: test
   password: test
   host: 0.0.0.0
-  port: 5433
+  port: 5432
 
 development:
   <<: *common

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,14 @@
+common: &common
+  adapter: postgresql
+  pool: 5
+  username: test
+  password: test
+  host: 0.0.0.0
+  port: 5433
+
+development:
+  <<: *common
+  database: alexgascon-api_development
+test:
+  <<: *common
+  database: alexgascon-api_test

--- a/db/migrate/20201122000732_create_health_meals.rb
+++ b/db/migrate/20201122000732_create_health_meals.rb
@@ -1,0 +1,13 @@
+class CreateHealthMeals < ActiveRecord::Migration[6.0]
+  def change
+    create_table :health_meals do |t|
+      t.float :carbohydrates_portions
+      t.datetime :date
+      t.text :food
+      t.text :meal_type
+      t.text :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,28 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_11_22_000732) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "health_meals", force: :cascade do |t|
+    t.float "carbohydrates_portions"
+    t.datetime "date"
+    t.text "food"
+    t.text "meal_type"
+    t.text "notes"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
       - POSTGRES_PASSWORD=test
       - POSTGRES_USER=test
     ports:
-      - "5433:5432"
+      - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  dynamo:
+    image: amazon/dynamodb-local
+    command: "-jar DynamoDBLocal.jar -inMemory -port 6000 -sharedDb"
+    ports:
+      - "6000:6000"
+  postgres:
+    image: postgres
+    volumes:
+      - "./docker-resources/postgres/data:/var/lib/postgresql/data"
+    environment:
+      - POSTGRES_PASSWORD=test
+      - POSTGRES_USER=test
+    ports:
+      - "5433:5432"

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/lib/tasks/prepare_test_db.rake
+++ b/lib/tasks/prepare_test_db.rake
@@ -1,0 +1,9 @@
+desc "Setup test database - drops, loads schema and migrates the test db"
+task prepare_test_db: :environment do
+  Rails.env = ENV['RAILS_ENV'] = 'test'
+  Rake::Task['db:drop'].invoke
+  Rake::Task['db:create'].invoke
+  Rake::Task['db:schema:load'].invoke
+  ActiveRecord::Base.establish_connection
+  Rake::Task['db:migrate'].invoke
+end

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -4,6 +4,9 @@ bundle exec jets deploy production
 echo "Creating the new DynamoDB tables..."
 JETS_ENV=production bundle exec rake dynamoid:create_tables
 
+echo "Running SQL migrations..."
+JETS_ENV=production bundle exec jets db:prepare
+
 echo "Updating the CloudFormation stacks..."
 for template_path in infrastructure/*
 do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,16 +6,20 @@ ENV['JETS_BUILD_NO_INTERNET'] = 'true'
 # Ensures AWS APIs are never called. Fixture home folder does not contain ~/.aws/credentials
 ENV['HOME'] = File.join(Dir.pwd, 'spec/fixtures/home')
 
+require 'active_support/testing/time_helpers'
 require 'byebug'
 require 'fileutils'
 require 'jets'
+require 'rake'
 require 'webmock/rspec'
-require 'active_support/testing/time_helpers'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
 abort('The Jets environment is running in production mode!') if Jets.env == 'production'
 Jets.boot
+
+Jets.load_tasks
+Rake::Task['prepare_test_db'].invoke
 
 require 'jets/spec_helpers'
 


### PR DESCRIPTION
### Why?
In the future, we want to enable searching meals with a specific food on them. With DynamoDB, full text searches are complex and usually require additional services (like ElasticSearch), so we will migrate the Meals model to a PostgreSQL DB and use its native full text search capabilities

### How?
We will use Jets Rails-like features to integrate with Postgres via ActiveRecord. This simplifies the integration.

Several changes to achieve it, in several areas:

1) Configuration
- Added a config/database.yml file with the DB configuration
- Added pg gem to enable Postgres integration
- Creating a Rake task to create DB and DB tables before starting the tests
- Adding the annotate gem + Rake task to annotate the model files with the schema configuration
- Creating a docker-compose file with both DBs (DynamoDB and Postgres) to simplify local testing
- Adding an additional command on the deploy script to run pending SQL migrations
- Modifying CircleCI config to also spin up a Postgres container

2) Code
- Creating an ApplicationRecord class to store the common ActiveRecord configuration
- Adapt the content of Health::Meal to use ActiveRecord instead of Dynamoid

(As the model interface is the same, we don't require changes in the codebase apart from the ones in the model)