### PR TITLE
Dexcom backfilling

### DIFF
--- a/app/factories/health/glucose_value_factory.rb
+++ b/app/factories/health/glucose_value_factory.rb
@@ -16,4 +16,11 @@ class Health::GlucoseValueFactory
       value: blood_glucose.value, timestamp: blood_glucose.timestamp
     )
   end
+
+  def self.from_dexcom_gem_entries(blood_glucoses)
+    glucose_values_data = blood_glucoses.map { |bg| { value: bg.value, timestamp: bg.timestamp } }
+
+    Jets.logger.warn("WARNING: Health::GlucoseValue.import is faster than individual saves, but doesn't run validations or callbacks")
+    Health::GlucoseValue.import(glucose_values_data)
+  end
 end

--- a/app/jobs/health/get_live_dexcom_data_job.rb
+++ b/app/jobs/health/get_live_dexcom_data_job.rb
@@ -7,8 +7,8 @@ module Health
     def run
       bgs = ::Dexcom::BloodGlucose.get_last(minutes: 1440)
 
-      bgs
-        .map { |bg| Health::GlucoseValueFactory.from_dexcom_gem(bg, persist=true) }
+      Health::GlucoseValueFactory
+        .from_dexcom_gem_entries(bgs)
         .each { |glucose_value| PublishCloudwatchDataCommand.new(glucose_value).execute }
     end
   end

--- a/app/jobs/health/get_live_dexcom_data_job.rb
+++ b/app/jobs/health/get_live_dexcom_data_job.rb
@@ -5,10 +5,11 @@ module Health
 
     rate '5 minutes'
     def run
-      bg = ::Dexcom::BloodGlucose.last
-      
-      glucose_value = Health::GlucoseValueFactory.from_dexcom_gem(bg, persist=true)
-      PublishCloudwatchDataCommand.new(glucose_value).execute
+      bgs = ::Dexcom::BloodGlucose.get_last(minutes: 1440)
+
+      bgs
+        .map { |bg| Health::GlucoseValueFactory.from_dexcom_gem(bg, persist=true) }
+        .each { |glucose_value| PublishCloudwatchDataCommand.new(glucose_value).execute }
     end
   end
 end

--- a/spec/jobs/health/get_live_dexcom_data_job_spec.rb
+++ b/spec/jobs/health/get_live_dexcom_data_job_spec.rb
@@ -24,8 +24,14 @@ RSpec.describe Health::GetLiveDexcomDataJob do
 
     it 'publishes the glucose metrics' do
       command_double = instance_double(PublishCloudwatchDataCommand)
-      allow(PublishCloudwatchDataCommand).to receive(:new).and_return(command_double)
+      allow(PublishCloudwatchDataCommand)
+        .to receive(:new)
+        .with(a_kind_of Health::GlucoseValue)
+        .and_return(command_double)
 
+      # NOTE: If this fails, maybe the method has been called, but not on the double
+      # That would mean that PublishCloudwatchDataCommand.new hasn't been called with
+      # an instance of Health::GlucoseValue
       expect(command_double).to receive(:execute).exactly(bg_datapoints).times
 
       subject


### PR DESCRIPTION
## Description

 Modifying Health::GetLiveDexcomDataJob to retrieve the datapoints in the 
 last 24h, instead of just the last datapoint. This will allow us to 
 retrieve backfilled data: data that may not have been available instantly
 (maybe because the sensor lost connectivity, or because the transmitter
 didn't publish it on time) but that gets eventually published

Related with #53: solves backfilling, but not the publication of repeated datapoints