### PR TITLE
Migrating AIB integration to Plaid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'factory_bot'
 gem 'httparty'
 gem 'parallel'
 gem 'pg'
+gem 'plaid', '~> 14.0.0.beta'
 gem 'telegram-bot-ruby'
 gem 'ynab'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,8 @@ GEM
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    plaid (14.0.0.beta.5)
+      faraday (~> 1.0, >= 1.0.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -338,6 +340,7 @@ DEPENDENCIES
   launchy
   parallel
   pg
+  plaid (~> 14.0.0.beta)
   pry
   pry-byebug
   pry-stack_explorer

--- a/app/factories/finance/plaid_client_factory.rb
+++ b/app/factories/finance/plaid_client_factory.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Finance
+  class PlaidClientFactory
+    PLAID_API_VERSION = '2020-09-14'
+
+    def self.build
+      configuration = Plaid::Configuration.new
+      configuration.server_index = Plaid::Configuration::Environment['development']
+      configuration.api_key['PLAID-CLIENT-ID'] = ENV['PLAID_CLIENT_ID']
+      configuration.api_key['PLAID-SECRET'] = ENV['PLAID_SECRET']
+      configuration.api_key['Plaid-Version'] = PLAID_API_VERSION
+
+      api_client = Plaid::ApiClient.new(configuration)
+
+      Plaid::PlaidApi.new(api_client)
+    end
+  end
+end

--- a/app/services/finance/aib/transaction_builder.rb
+++ b/app/services/finance/aib/transaction_builder.rb
@@ -6,7 +6,7 @@ module Finance
       private
 
       def amount_in_cents
-        @transaction_information['amount'] * CENTS_PER_EURO
+        -@transaction_information['amount'] * CENTS_PER_EURO
       end
 
       def bank
@@ -18,11 +18,11 @@ module Finance
       end
 
       def transaction_datetime
-        DateTime.parse(@transaction_information['timestamp']).in_time_zone('Europe/Dublin').to_date
+        DateTime.parse(@transaction_information['date']).in_time_zone('Europe/Dublin').to_date
       end
 
       def description
-        @transaction_information['description']
+        @transaction_information['name']
       end
     end
   end

--- a/spec/factories/finance/plaid_objects.rb
+++ b/spec/factories/finance/plaid_objects.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :plaid_account, class: Plaid::AccountBase do
+    account_id   { 'm7utN1reMvMx7KndcdZtJqm1CLTmDgqkQNM9A' }
+    balances     { build_list(:plaid_account_balance, 1) }
+    mask         { '1234' }
+    name         { 'CURRENT-1234' }
+    subtype      { 'checking' }
+    type         { 'depository' }
+  end
+
+  factory :plaid_account_balance, class: Plaid::AccountBalance do
+    available         { 12_345.67 }
+    current           { 12_346.88 }
+    iso_currency_code { 'EUR' }
+  end
+
+  factory :plaid_item, class: Plaid::Item do
+    available_products      { ['balance'] }
+    billed_products         { %w[auth transactions] }
+    institution_id          { 'ins_123456' }
+    item_id                 { 'DPBDHk12yCZPLRGY4WO0LiDX08huFsnuCTkUE' }
+    update_type             { 'background' }
+    webhook                 { 'example.com/webhooks'}
+    consent_expiration_time { '2021-08-23T18:53:12Z' }
+  end
+
+  factory :plaid_transaction, class: Plaid::Transaction do
+    account_id              { 'm7utN1reMvMx7KndcdZtJqm1CLTmDgqkQNM9A' }
+    amount                  { 11.39 }
+    category                { ['Food and Drink', 'Restaurants'] }
+    category_id             { '13005000' }
+    date                    { '2021-06-11' }
+    iso_currency_code       { 'EUR' }
+    location                { association :plaid_location }
+    merchant_name           { 'Deliveroo' }
+    name                    { 'DELIVEROO' }
+    payment_channel         { 'in store' }
+    payment_meta            { association :plaid_payment_meta }
+    pending                 { false }
+    pending_transaction_id  { 'kk3t7qLhjQGfbZZma4WFPLldcfEexKGAE1lqy' }
+    transaction_id          { 'W00Vi6WZnIL0J4I0ToP2uTjvb3GgCvjKmX4c3' }
+    transaction_type        { 'place' }
+  end
+
+  factory :plaid_location, class: Plaid::Location do
+    address       { 'Fake street, 123' }
+    city          { 'Springfield' }
+    country       { 'Fakeland' }
+    lat           { 12.34 }
+    lon           { -65.42 }
+    postal_code   { '23118' }
+    region        { 'Co. Fakeland' }
+    store_number  { 55 }
+  end
+
+  factory :plaid_payment_meta, class: Plaid::PaymentMeta do
+  end
+
+  factory :plaid_transactions_get_response, class: Plaid::TransactionsGetResponse do
+    request_id         { 'SmOtM4iZvnZCCNdllQjnFlGXn3u0jkXWkmkTe' }
+    accounts           { build_list(:plaid_account, 1) }
+    item               { association(:plaid_item) }
+    total_transactions { 1 }
+    transactions       { build_list(:plaid_transaction, 1) }
+  end
+end

--- a/spec/fixtures/finance/aib/transaction.json
+++ b/spec/fixtures/finance/aib/transaction.json
@@ -1,13 +1,45 @@
 {
-    "timestamp":"2020-08-10T23:00:00Z",
-    "description":"VDP-AMZNMktplace",
-    "transaction_type":"DEBIT",
-    "transaction_category":"DEBIT",
-    "transaction_classification":[],
-    "amount":-26.37,
-    "currency":"EUR",
-    "transaction_id":"7ee551d422dfd72ebe2b144396bb280c",
-    "meta": {
-        "transaction_type":"Debit"
-    }
+    "account_id": "yV6uV9apMQkufWNPCkwLnkpHtRAEVumx6WoH7",
+    "account_owner": null,
+    "amount": 20,
+    "authorized_date": null,
+    "authorized_datetime": null,
+    "category": [
+        "Transfer",
+        "Withdrawal",
+        "ATM"
+    ],
+    "category_id": "21012002",
+    "date": "2021-05-24",
+    "datetime": null,
+    "iso_currency_code": "EUR",
+    "location": {
+        "address": null,
+        "city": null,
+        "country": null,
+        "lat": null,
+        "lon": null,
+        "postal_code": null,
+        "region": null,
+        "store_number": null
+    },
+    "merchant_name": null,
+    "name": "ATM FAKE STREET 22MAY21 TIME 12:18",
+    "payment_channel": "other",
+    "payment_meta": {
+        "by_order_of": null,
+        "payee": null,
+        "payer": null,
+        "payment_method": null,
+        "payment_processor": null,
+        "ppd_id": null,
+        "reason": null,
+        "reference_number": null
+    },
+    "pending": false,
+    "pending_transaction_id": null,
+    "transaction_code": null,
+    "transaction_id": "aJgKYrKa7Yt7oe3pb68qiX509M3gKgCjb9J4y",
+    "transaction_type": "special",
+    "unofficial_currency_code": null
 }

--- a/spec/services/finance/aib/service_spec.rb
+++ b/spec/services/finance/aib/service_spec.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples 'auth error metric' do |metric_value|
   it "emits an auth error metric with value #{metric_value}" do
     auth_error_metric = Metrics::BaseMetric.new
-    auth_error_metric.namespace = "Infrastructure/Finance"
+    auth_error_metric.namespace = 'Infrastructure/Finance'
     auth_error_metric.metric_name = 'Auth error'
     auth_error_metric.unit = 'Count'
     auth_error_metric.value = metric_value
@@ -49,24 +49,32 @@ RSpec.shared_examples 'exception metric' do |metric_value|
 end
 
 RSpec.describe Finance::Aib::Service do
-  let(:truelayer_credentials) do
+  let(:credentials) do
     {
-      TRUELAYER_AIB_ACCOUNT_ID: '123456789009876543212',
-      TRUELAYER_BASE_URL: 'fake-truelayer.com',
-      TRUELAYER_CLIENT_ID: 'myclientid-1234ab',
-      TRUELAYER_CLIENT_SECRET: 'e9f9a53e-9db9-4707-aaa7-c9a117b4d12c',
-      TRUELAYER_REDIRECT_URL: 'https://redirect.fake-truelayer.com/redirect'
+      PLAID_ACCESS_TOKEN: 'access-development-12345678-9abc-deff-edcb-a98765432100'
     }
   end
-
-  let(:content_type_json) { { 'Content-Type'=> 'application/json' } }
+  let(:transactions_get_request) do
+    Plaid::TransactionsGetRequest.new(
+      access_token: 'access-development-12345678-9abc-deff-edcb-a98765432100',
+      start_date: '2020-07-31',
+      end_date: '2020-08-01'
+    )
+  end
 
   before do
     travel_to Time.new(2020, 8, 1, 12, 34, 56)
+    allow_any_instance_of(Plaid::PlaidApi)
+      .to receive(:transactions_get)
+      .with(
+        fields_with_values(start_date: '2020-07-31', end_date: '2020-08-01', access_token: 'access-development-12345678-9abc-deff-edcb-a98765432100')
+        .and be_a_kind_of(Plaid::TransactionsGetRequest)
+      )
+      .and_return(transactions_get_response)
     stub_command PublishCloudwatchDataCommand
   end
 
-  around { |example| with_modified_env(truelayer_credentials) { example.run } }
+  around { |example| with_modified_env(credentials) { example.run } }
 
   after do
     travel_back
@@ -75,25 +83,13 @@ RSpec.describe Finance::Aib::Service do
   subject { described_class.new.get_transactions(Time.now.yesterday, Time.now) }
 
   describe 'get_transactions' do
-    let(:get_transactions_request) do
-      stub_request(:get, 'https://api.fake-truelayer.com/data/v1/accounts/123456789009876543212/transactions')
-      .with(
-        headers: { 'Authorization' => 'Bearer defaultFactoryAccessToken' },
-        query: { from: '2020-07-30T23:00:00Z', to: '2020-08-01T22:59:59Z' }
-      )
-    end
-    let(:get_transactions_response) { load_json_fixture 'finance/truelayer/aib_transactions_response' }
-
+    let(:transactions_get_response) { build(:plaid_transactions_get_response) }
 
     context 'when a valid token exists' do
-      before do
-        FactoryBot.create(:aib_token, expiration_time: Time.now.to_i + 200)
-        get_transactions_request.to_return(status: 200, body: get_transactions_response.to_json, headers: content_type_json)
-      end
+      before { FactoryBot.create(:aib_token, expiration_time: Time.now.to_i + 200) }
 
       it 'retrieves the bank movements' do
-        expected_movements = load_json_fixture('finance/truelayer/aib_transactions')
-        expect(subject).to eq expected_movements
+        expect(subject.first).to eq build(:plaid_transaction)
       end
 
       include_examples 'auth error metric', 0
@@ -103,7 +99,7 @@ RSpec.describe Finance::Aib::Service do
       include_examples 'exception metric', 0
 
       context 'when there are no bank movements' do
-        let(:get_transactions_response) { load_json_fixture 'finance/truelayer/no_transactions' }
+        let(:transactions_get_response) { build(:plaid_transactions_get_response, transactions: [], total_transactions: 0) }
 
         it 'returns an empty array' do
           expect(subject).to eq []

--- a/spec/services/finance/aib/transaction_builder_spec.rb
+++ b/spec/services/finance/aib/transaction_builder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Finance::Aib::TransactionBuilder do
     subject(:bank_transaction) { described_class.new(transaction_information).build }
 
     it 'sets the amount_in_cents' do
-      expect(bank_transaction.amount_in_cents).to eq -2637
+      expect(bank_transaction.amount_in_cents).to eq -2000
     end
 
     it 'sets the bank' do
@@ -15,23 +15,23 @@ RSpec.describe Finance::Aib::TransactionBuilder do
     end
 
     it 'sets the datetime' do
-      expect(bank_transaction.datetime).to eq DateTime.parse('2020-08-11')
+      expect(bank_transaction.datetime).to eq DateTime.parse('2021-05-24')
     end
 
     it 'sets the description' do
-      expect(bank_transaction.description).to eq 'VDP-AMZNMktplace'
+      expect(bank_transaction.description).to eq 'ATM FAKE STREET 22MAY21 TIME 12:18'
     end
 
     it 'sets the internal_id' do
-      expect(bank_transaction.internal_id).to eq '7ee551d422dfd72ebe2b144396bb280c'
+      expect(bank_transaction.internal_id).to eq 'aJgKYrKa7Yt7oe3pb68qiX509M3gKgCjb9J4y'
     end
 
     it 'sets year_month' do
-      expect(bank_transaction.year_month).to eq '2020-08'
+      expect(bank_transaction.year_month).to eq '2021-05'
     end
 
     it 'sets day' do
-      expect(bank_transaction.day).to eq '11'
+      expect(bank_transaction.day).to eq '24'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,16 @@ RSpec.configure do |c|
   c.include ActiveSupport::Testing::TimeHelpers
 end
 
+RSpec::Matchers.define :have_fields do |fields|
+  match do |actual|
+    fields.each_pair do |field, expected_value|
+      actual.send(field) == expected_value
+    end
+  end
+end
+
+RSpec::Matchers.alias_matcher :fields_with_values, :have_fields
+
 def with_modified_env(options, &block)
   ClimateControl.modify(options, &block)
 end


### PR DESCRIPTION
## Description
After Brexit, Truelayer stopped supporting EU banks in their free accounts. Therefore, the AIB integration has been broken since then

These changes remove Truelayer and migrate to Plaid for the AIB integration

## How?
Instead of integrating with the API directly, we will use the official Plaid library for Ruby. And, given that this is a non-critical workflow, we will use their Beta libraries ([link](https://github.com/plaid/plaid-ruby/tree/14.0.0-beta-release)) instead of the normal ones. The logic is pretty different, so better to start with the implementation that will be stable in the future to avoid a re-write in a few months.
