### PR TITLE
Bugfix: Correctly specify token for Plaid

### DIFF
--- a/app/services/finance/aib/service.rb
+++ b/app/services/finance/aib/service.rb
@@ -37,7 +37,7 @@ module Finance
         to = to.strftime('%Y-%m-%d')
 
         request_data = Plaid::TransactionsGetRequest.new(
-          access_token: @auth_token,
+          access_token: @auth_token.access_token,
           start_date: from,
           end_date: to
         )
@@ -60,6 +60,9 @@ module Finance
       end
 
       def handle_error(additional_data, error_type)
+        Jets.logger.warn "ERROR - #{error_type}"
+        Jets.logger.warn "ERROR INFO - #{additional_data}"
+
         case error_type
         when :auth
           handle_auth_error(additional_data)

--- a/spec/matchers/have_fields_spec.rb
+++ b/spec/matchers/have_fields_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RSpec::Matcher have_fields' do
+  class Person
+    attr_accessor :age, :name
+
+    def initialize(name, age)
+      @name = name
+      @age = age
+    end
+  end
+
+  let(:alex) { Person.new('Alex', 28) }
+
+  it 'matches if all the values match' do
+    expect(alex).to have_fields(name: 'Alex', age: 28)
+  end
+
+  it 'matches if not all arguments are specified' do
+    expect(alex).to have_fields(name: 'Alex')
+    expect(alex).to have_fields(age: 28)
+  end
+
+  it 'does not match if any value does not match' do
+    expect(alex).not_to have_fields(name: 'Paco', age: 28)
+  end
+
+  it 'fails if the object does not have that field' do
+    expect(alex).not_to have_fields(country: 'Spain')
+  end
+
+  it 'is aliased as fields_with_values' do
+    expect(alex).to fields_with_values(name: 'Alex', age: 28)
+  end
+end

--- a/spec/services/finance/aib/service_spec.rb
+++ b/spec/services/finance/aib/service_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Finance::Aib::Service do
     allow_any_instance_of(Plaid::PlaidApi)
       .to receive(:transactions_get)
       .with(
-        fields_with_values(start_date: '2020-07-31', end_date: '2020-08-01', access_token: 'access-development-12345678-9abc-deff-edcb-a98765432100')
+        fields_with_values(start_date: '2020-07-31', end_date: '2020-08-01', access_token: 'defaultFactoryAccessToken')
         .and be_a_kind_of(Plaid::TransactionsGetRequest)
       )
       .and_return(transactions_get_response)
@@ -135,7 +135,7 @@ RSpec.describe Finance::Aib::Service do
           allow_any_instance_of(Plaid::PlaidApi)
             .to receive(:transactions_get)
             .with(
-              fields_with_values(start_date: '2020-07-31', end_date: '2020-08-01', access_token: 'access-development-12345678-9abc-deff-edcb-a98765432100')
+              fields_with_values(start_date: '2020-07-31', end_date: '2020-08-01', access_token: 'defaultFactoryAccessToken')
               .and be_a_kind_of(Plaid::TransactionsGetRequest)
             ).and_raise plaid_auth_error
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,16 +37,6 @@ RSpec.configure do |c|
   c.include ActiveSupport::Testing::TimeHelpers
 end
 
-RSpec::Matchers.define :have_fields do |fields|
-  match do |actual|
-    fields.each_pair do |field, expected_value|
-      actual.send(field) == expected_value
-    end
-  end
-end
-
-RSpec::Matchers.alias_matcher :fields_with_values, :have_fields
-
 def with_modified_env(options, &block)
   ClimateControl.modify(options, &block)
 end

--- a/spec/support/matchers/have_fields.rb
+++ b/spec/support/matchers/have_fields.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :have_fields do |fields|
+  match do |actual|
+    fields.all? { |field, expected_value| actual.send(field) == expected_value }
+  rescue NoMethodError
+    false
+  end
+end
+
+RSpec::Matchers.alias_matcher :fields_with_values, :have_fields


### PR DESCRIPTION
The previous implementation of the Plaid integration failed because we
were sending the entire AuthToken instead of just the access_token. This
commit fixes that.

Additionally, we fix a bug in the custom have_fields RSpec matcher,
which wasn't correctly failing if some of the fields weren't
matching. We have also added tests for the matcher to catch similar
errors earlier in the future