### PR TITLE
Adding Redis cache to avoid datapoint duplication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
               environment:
                 POSTGRES_PASSWORD: 'test'
                 POSTGRES_USER: 'test'
+            - image: redis
+              command: redis-server --requirepass "pass"
     "ruby-26":
         <<: *common
         docker:
@@ -55,6 +57,8 @@ jobs:
               environment:
                 POSTGRES_PASSWORD: 'test'
                 POSTGRES_USER: 'test'
+            - image: redis
+              command: redis-server --requirepass "pass"
     "ruby-27":
         <<: *common
         docker:
@@ -68,6 +72,8 @@ jobs:
               environment:
                 POSTGRES_PASSWORD: 'test'
                 POSTGRES_USER: 'test'
+            - image: redis
+              command: redis-server --requirepass "pass"
 workflows:
   version: 2.1
   build:

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'httparty'
 gem 'parallel'
 gem 'pg'
 gem 'plaid', '~> 14.0.0.beta'
+gem 'redis'
 gem 'telegram-bot-ruby'
 gem 'ynab'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     recursive-open-struct (1.1.3)
+    redis (4.3.1)
     regexp_parser (2.0.3)
     rexml (3.2.5)
     rspec (3.10.0)
@@ -346,6 +347,7 @@ DEPENDENCIES
   pry-stack_explorer
   puma (= 4.3.8)
   rack
+  redis
   rspec
   rubocop
   shotgun
@@ -354,4 +356,4 @@ DEPENDENCIES
   ynab
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/jobs/health/get_live_dexcom_data_job.rb
+++ b/app/jobs/health/get_live_dexcom_data_job.rb
@@ -2,15 +2,49 @@
 
 module Health
   class GetLiveDexcomDataJob < ApplicationJob
+    THREE_HOURS_IN_MINUTES = 180
 
     rate '5 minutes'
     def run
-      bgs = ::Dexcom::BloodGlucose.get_last(minutes: 180)
+      bgs = ::Dexcom::BloodGlucose.get_last(minutes: THREE_HOURS_IN_MINUTES)
 
       Health::GlucoseValueFactory
         .from_dexcom_gem_entries(bgs)
+        .reject { |glucose_value| already_published?(glucose_value) }
         .tap { |glucose_values| Jets.logger.info "Number of glucose values to publish: #{glucose_values.size}" }
-        .each { |glucose_value| PublishCloudwatchDataCommand.new(glucose_value).execute }
+        .each { |glucose_value| publish(glucose_value) }
+    end
+
+    private
+
+    def already_published?(glucose_value)
+      Redis.current.get(glucose_value.timestamp.to_s).present?
+    rescue Redis::BaseError
+      Jets.logger.warn 'Redis is unavailable - Skipping cache read'
+      publish_redis_metric
+
+      false
+    end
+
+    def publish(glucose_value)
+      PublishCloudwatchDataCommand.new(glucose_value).execute
+
+      Redis.current.set(glucose_value.timestamp.to_s, true)
+    rescue Redis::BaseError
+      Jets.logger.warn 'Redis is unavailable - Skipping cache write'
+      publish_redis_metric
+    end
+
+    def publish_redis_metric
+      metric = Metrics::BaseMetric.new
+      metric.namespace = Metrics::Namespaces::INFRASTRUCTURE
+      metric.unit = Metrics::Units::COUNT
+      metric.timestamp = DateTime.now
+      metric.dimensions = [{ name: 'Component', value: 'Redis' }]
+      metric.metric_name = 'Error'
+      metric.value = 1
+
+      PublishCloudwatchDataCommand.new(metric).execute
     end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,3 +13,5 @@ Dynamoid.configure do |config|
   config.read_capacity = 1
   config.write_capacity = 1
 end
+
+ENV['REDIS_PASSWORD'] = 'pass'

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Redis.current = Redis.new(
+  host: ENV['REDIS_HOST'],
+  port: ENV['REDIS_PORT'],
+  password: ENV['REDIS_PASSWORD']
+)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,8 @@ services:
       - POSTGRES_USER=test
     ports:
       - "5432:5432"
+  redis:
+    image: redis
+    command: redis-server --requirepass "pass"
+    ports:
+      - "6379:6379"

--- a/infrastructure/Alarms-Infrastructure.yml
+++ b/infrastructure/Alarms-Infrastructure.yml
@@ -223,3 +223,19 @@ Resources:
           ReturnData: false
       AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
       OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+
+  RedisErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alexgascon-api_Redis-Error
+      AlarmDescription: Fires if we get an error when using the Redis cache that prevents duplication of Dexcom metrics
+      EvaluationPeriods: 1
+      Namespace: Infrastructure
+      MetricName: Error
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Statistic: Sum
+      Period: 300
+      TreatMissingData: notBreaching
+      AlarmActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']
+      OKActions: ['arn:aws:sns:eu-west-1:598877714121:AlarmFired']

--- a/spec/jobs/health/get_live_dexcom_data_job_spec.rb
+++ b/spec/jobs/health/get_live_dexcom_data_job_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Health::GetLiveDexcomDataJob do
+  let(:redis_env) do
+    {
+      'REDIS_HOST' => 'localhost',
+      'REDIS_PORT' => '6379',
+      'REDIS_PASSWORD' => 'pass'
+    }
+  end
+
   describe '#run' do
     let(:minutes) { 180 }
     let(:bg_datapoints) { minutes / 5 }
@@ -9,7 +17,19 @@ RSpec.describe Health::GetLiveDexcomDataJob do
       bgs = build_list(:dexcom_blood_glucose, bg_datapoints)
       allow(Dexcom::BloodGlucose).to receive(:get_last).with(minutes: minutes).and_return(bgs)
 
-      stub_command(PublishCloudwatchDataCommand)
+      @command_double = instance_double(PublishCloudwatchDataCommand)
+      allow(PublishCloudwatchDataCommand)
+        .to receive(:new)
+        .with(a_kind_of Health::GlucoseValue)
+        .and_return(@command_double)
+      allow(@command_double).to receive(:execute)
+    end
+
+    around do |example|
+      with_modified_env(redis_env) do
+        example.run
+        Redis.current.flushall
+      end
     end
 
     subject { described_class.perform_now(:run) }
@@ -23,18 +43,51 @@ RSpec.describe Health::GetLiveDexcomDataJob do
     end
 
     it 'publishes the glucose metrics' do
-      command_double = instance_double(PublishCloudwatchDataCommand)
-      allow(PublishCloudwatchDataCommand)
-        .to receive(:new)
-        .with(a_kind_of Health::GlucoseValue)
-        .and_return(command_double)
-
       # NOTE: If this fails, maybe the method has been called, but not on the double
       # That would mean that PublishCloudwatchDataCommand.new hasn't been called with
       # an instance of Health::GlucoseValue
-      expect(command_double).to receive(:execute).exactly(bg_datapoints).times
+      expect(@command_double).to receive(:execute).exactly(bg_datapoints).times
 
       subject
+    end
+
+    context 'when a glucose value was recently published' do
+      it 'does not publish the glucose metric again' do
+        expect(@command_double).to receive(:execute).exactly(bg_datapoints).times
+        described_class.perform_now(:run)
+
+        expect(@command_double).not_to receive(:execute)
+        described_class.perform_now(:run)
+      end
+    end
+
+    context 'when Redis is unavailable' do
+      before do
+        allow(Redis.current).to receive(:get).and_raise(Redis::BaseError)
+        allow(Redis.current).to receive(:set).and_raise(Redis::BaseError)
+
+        @redis_metric_command_double = instance_double(PublishCloudwatchDataCommand)
+        allow(PublishCloudwatchDataCommand)
+          .to receive(:new)
+          .with(
+            a_kind_of(Metrics::BaseMetric)
+            .and fields_with_values(namespace: 'Infrastructure', metric_name: 'Error')
+          )
+          .and_return(@redis_metric_command_double)
+        allow(@redis_metric_command_double).to receive(:execute)
+      end
+
+      it 'publishes all values' do
+        expect(@command_double).to receive(:execute).exactly(bg_datapoints)
+
+        subject
+      end
+
+      it 'publishes the error metric' do
+        expect(@redis_metric_command_double).to receive(:execute)
+
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #53

With each execution of Health::GetLiveDexcomDataJob, we retrieve all the
datapoints corresponding to the last 3h and publish them in CloudWatch.
This is helpful to avoid missing datapoints in case the datapoints get
published to Dexcom with a delay (e.g. the transmitter slows down or
loses connection for a few minutes). However, it also means that when
everything works correctly, we will be publishing each datapoint
multiple times, which is an inefficient use of CloudWatch

Here we resolve that problem by adding a Redis DB that we will use as a
deduplication cache: whenever we publish a glucose value in CloudWatch,
we will store its timestamp in Redis. On each execution, before getting
to the CloudWatch publication part, we will check if the timestamps are
present in Redis, and filter them out if that's the case

Also, as we don't want this to be a critical blocker, we will just
ignore Redis in case it raises errors, and assume that the datapoint is
not published