### PR TITLE
Migrating to CircleCI native images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,13 @@ common: &common
                 gem install bundler
         - restore_cache:
             keys:
-                - v1-dep-bundle-{{ checksum "Gemfile.lock" }}-{{ .Environment.CIRCLE_JOB }}
+                - v2-dep-bundle-{{ checksum "Gemfile.lock" }}-{{ .Environment.CIRCLE_JOB }}
         - run:
             name: Install dependencies
             command: |
                 bundle install --jobs=4 --retry=3 --path vendor/bundle
         - save_cache:
-            key: v1-dep-bundle-{{ checksum "Gemfile.lock" }}-{{ .Environment.CIRCLE_JOB }}
+            key: v2-dep-bundle-{{ checksum "Gemfile.lock" }}-{{ .Environment.CIRCLE_JOB }}
             paths:
                 - vendor/bundle
         - run:
@@ -32,7 +32,7 @@ jobs:
     "ruby-27":
         <<: *common
         docker:
-            - image: ruby:2.7
+            - image: cimg/ruby:2.7
               environment:
                 AWS_ACCESS: 'fakeAccessKey'
                 AWS_SECRET: 'fakeSecretKey'


### PR DESCRIPTION
CircleCI has updated their docker images for languages, and the old ones
will get deprecated by the end of the year.

More info: https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/

Additionally, when trying to update, restoring the cache results in an error. To prevent problems, we will update our cache version to v2, to start from scratch when using the newer images

Example of a failed build: https://app.circleci.com/pipelines/github/AlexGascon/alexgascon-api/77/workflows/7b13bc9c-7fc3-4400-8da7-4b987dd20583/jobs/218
