### PR TITLE
Exclude pending transactions from AIB

### DIFF
--- a/app/services/finance/aib/service.rb
+++ b/app/services/finance/aib/service.rb
@@ -19,7 +19,9 @@ module Finance
 
         response = request_transactions(from, to)
 
-        response.transactions
+        response
+          .transactions
+          .reject { |transaction| transaction.pending }
       rescue Finance::Aib::AuthError => e
         handle_error(e, :auth)
       rescue Plaid::ApiError => e

--- a/spec/factories/finance/plaid_objects.rb
+++ b/spec/factories/finance/plaid_objects.rb
@@ -42,6 +42,10 @@ FactoryBot.define do
     pending_transaction_id  { 'kk3t7qLhjQGfbZZma4WFPLldcfEexKGAE1lqy' }
     transaction_id          { 'W00Vi6WZnIL0J4I0ToP2uTjvb3GgCvjKmX4c3' }
     transaction_type        { 'place' }
+
+    trait :pending do
+      pending { true }
+    end
   end
 
   factory :plaid_location, class: Plaid::Location do
@@ -64,5 +68,12 @@ FactoryBot.define do
     item               { association(:plaid_item) }
     total_transactions { 1 }
     transactions       { build_list(:plaid_transaction, 1) }
+
+    trait :with_pending_transactions do
+      after(:build) do |response|
+        response.transactions = response.transactions + build_list(:plaid_transaction, 1, :pending)
+        response.total_transactions = 2
+      end
+    end
   end
 end

--- a/spec/services/finance/aib/service_spec.rb
+++ b/spec/services/finance/aib/service_spec.rb
@@ -106,6 +106,17 @@ RSpec.describe Finance::Aib::Service do
         end
       end
 
+      context 'when an operation is not confirmed' do
+        let(:transactions_get_response) { build(:plaid_transactions_get_response, :with_pending_transactions) }
+
+        it 'returns only the confirmed operations' do
+          transactions = subject
+
+          expect(transactions.count).to eq 1
+          expect(transactions.first.pending).to be false
+        end
+      end
+
       context 'when we get an exception' do
         before do
           allow_any_instance_of(described_class)


### PR DESCRIPTION
## Description
Currently we are processing AIB transactions twice: once when they
happen for the first time, and another one when they are confirmed. This
happens because most AIB transactions are initially marked as pending,
and only get confirmed after 1/2 days.

The goal of this change is to stop processing transactions that haven't
been confirmed yet, on the one hand to avoid this double processing that
we mentioned, and on the other because the details might not be final
and therefore the accumulated data will be incorrect at the end of the
month