### PR TITLE
Redis expiration time

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.6)
     recursive-open-struct (1.1.3)
-    redis (4.3.1)
+    redis (4.5.1)
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rspec (3.10.0)


### PR DESCRIPTION
### Description                                                                                                                                                                                        
Given that we only use Redis keys for a max of three hours, we will set an expiration time on them to make sure that they don't keep accumulating after they are no longer needed. This will help us save space in our Redis cluster                                                                                                                                                                                                

                                               
To add an extra safety margin, we will expire keys after six hours instead of three as the current job reads. This should never be needed, but given that we are supposed to have a small number of keys, the extra space these keys will generate doesn't really matter                                             