### PR TITLE
Alerting when Plaid consent expires

### DIFF
--- a/spec/factories/finance/plaid_objects.rb
+++ b/spec/factories/finance/plaid_objects.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
     update_type             { 'background' }
     webhook                 { 'example.com/webhooks'}
     consent_expiration_time { '2021-08-23T18:53:12Z' }
+
+    trait :with_expired_consent do
+      consent_expiration_time { '2000-01-01T00:00:00Z' }
+    end
   end
 
   factory :plaid_transaction, class: Plaid::Transaction do
@@ -74,6 +78,11 @@ FactoryBot.define do
         response.transactions = response.transactions + build_list(:plaid_transaction, 1, :pending)
         response.total_transactions = 2
       end
+    end
+
+    trait :with_expired_consent do
+      item { association(:plaid_item, :with_expired_consent) }
+      transactions { [] }
     end
   end
 end

--- a/spec/services/finance/aib/service_spec.rb
+++ b/spec/services/finance/aib/service_spec.rb
@@ -161,6 +161,16 @@ RSpec.describe Finance::Aib::Service do
 
         include_examples 'exception metric', 0
       end
+
+      context 'when Plaid consent has expired' do
+        let(:transactions_get_response) { build(:plaid_transactions_get_response, :with_expired_consent) }
+
+        include_examples 'auth error metric', 1
+
+        include_examples 'request error metric', 0
+
+        include_examples 'exception metric', 0
+      end
     end
 
     context 'when the access token has expired' do


### PR DESCRIPTION
## Description
Plaid uses OpenBanking APIs, so user consent needs to be
renewed periodically for security reasons (in Europe at least). The
problem is that Plaid does not emit any kind of error when the consent
expires, it just stops retrieving transactions.

The goal of this change is to check the consent expiration each time that
we get a response from Plaid, and confirm that it's still valid. If not,
raise an Auth exception, so our monitoring system detects the problem