### PR TITLE
Getting 24h of Dexcom values instead of 3h

### DIFF
--- a/app/jobs/health/get_live_dexcom_data_job.rb
+++ b/app/jobs/health/get_live_dexcom_data_job.rb
@@ -2,12 +2,13 @@
 
 module Health
   class GetLiveDexcomDataJob < ApplicationJob
-    THREE_HOURS_IN_MINUTES = 180
-    CACHE_EXPIRATION_TIME_IN_SECONDS = THREE_HOURS_IN_MINUTES * 60 * 2 # Adding an extra margin
+    TWENTY_FOUR_HOURS_IN_MINUTES = 1440
+    DEXCOM_QUERY_RANGE_IN_MINUTES = TWENTY_FOUR_HOURS_IN_MINUTES
+    CACHE_EXPIRATION_TIME_IN_SECONDS = DEXCOM_QUERY_RANGE_IN_MINUTES * 60 * 2 # Adding an extra margin
 
     rate '5 minutes'
     def run
-      bgs = ::Dexcom::BloodGlucose.get_last(minutes: THREE_HOURS_IN_MINUTES)
+      bgs = ::Dexcom::BloodGlucose.get_last(minutes: DEXCOM_QUERY_RANGE_IN_MINUTES)
 
       Health::GlucoseValueFactory
         .from_dexcom_gem_entries(bgs)

--- a/spec/jobs/health/get_live_dexcom_data_job_spec.rb
+++ b/spec/jobs/health/get_live_dexcom_data_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Health::GetLiveDexcomDataJob do
   end
 
   describe '#run' do
-    let(:minutes) { 180 }
+    let(:minutes) { 1440 }
     let(:bg_datapoints) { minutes / 5 }
 
     before do


### PR DESCRIPTION
Previously, we were getting 3h because that is the max amount of data that is stored in the transmitter locally, if it's not able to send it to the cloud. That means that if there was data that wasn't published in the previous 3h, that data was going to be lost.

However, now the Dexcom Share app seems to be misbehaving, and even if the data is successfully published from the transmitter to the Dexcom app, it's not available on Share on time. It eventually is available, but that might happen out of the 3h query period that we were using, and therefore we won't get the data.

The goal of this change is to change the query period to 24h, the max allowed by Dexcom, to ensure that we get all the data that is eventually published, even if it's with a lot of delay. This will give us at least allow to have it for historic purposes (e.g. check the specific value of glucose a week ago)